### PR TITLE
Enable assign variables

### DIFF
--- a/latexify/core.py
+++ b/latexify/core.py
@@ -243,7 +243,7 @@ def get_latex(fn, math_symbol=True):
     source = inspect.getsource(fn)
   except Exception:
     # Maybe running on console.
-    source = dill.source.getsource(fn, enclosing=True)
+    source = dill.source.getsource(fn)
   return LatexifyVisitor(math_symbol=math_symbol).visit(ast.parse(source))
 
 

--- a/latexify/core.py
+++ b/latexify/core.py
@@ -58,7 +58,7 @@ class LatexifyVisitor(ast.NodeVisitor):
     for body_item in node.body[:-1]:
       self.visit(body_item)
     return_str = self.visit(node.body[-1])
-    return name_str + '(' + ', '.join(arg_strs) + r')\triangleq ' + return_str
+    return name_str + '(' + ', '.join(arg_strs) + r') \triangleq ' + return_str
 
   def visit_Return(self, node):
     return self.visit(node.value)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,7 +22,7 @@ def solve(a, b, c):
   return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)
 
 
-solve_latex = r'\operatorname{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
+solve_latex = r'\mathrm{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
 
 
 def sinc(x):
@@ -33,7 +33,7 @@ def sinc(x):
 
 
 sinc_latex = (
-  r'\operatorname{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ x=0 \\ '
+  r'\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ x=0 \\ '
   r'\frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array} \right.'
 )
 
@@ -42,8 +42,8 @@ def xtimesbeta(x, beta):
   return x * beta
 
 
-xtimesbeta_latex = r'\operatorname{xtimesbeta}(x, {\beta}) \triangleq x{\beta}'
-xtimesbeta_latex_no_symbols = r'\operatorname{xtimesbeta}(x, beta) \triangleq xbeta'
+xtimesbeta_latex = r'\mathrm{xtimesbeta}(x, {\beta}) \triangleq x{\beta}'
+xtimesbeta_latex_no_symbols = r'\mathrm{xtimesbeta}(x, beta) \triangleq xbeta'
 
 
 func_and_latex_str_list = [
@@ -64,4 +64,4 @@ def test_with_latex_to_str(func, expected_latex, math_symbol):
   else:
     latexified_function = with_latex(math_symbol=math_symbol)(func)
   assert str(latexified_function) == expected_latex
-  assert latexified_function._repr_latex_() == expected_latex
+  assert expected_latex in latexified_function._repr_latex_()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,10 +19,16 @@ from latexify import with_latex
 
 
 def solve(a, b, c):
-  return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)
-
+  return (-b + math.sqrt(b**2 - 4 * a * c)) / (2 * a)
 
 solve_latex = r'\mathrm{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
+
+def solve_with_assign(a, b, c):
+  numerator = (-b + math.sqrt(b ** 2 - 4 * a * c))
+  denominator = 2 * a
+  return numerator / denominator
+
+solve_with_assign_latex = r'\mathrm{solve_with_assign}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
 
 
 def sinc(x):
@@ -48,6 +54,7 @@ xtimesbeta_latex_no_symbols = r'\mathrm{xtimesbeta}(x, beta) \triangleq xbeta'
 
 func_and_latex_str_list = [
   (solve, solve_latex, None),
+  (solve_with_assign, solve_with_assign_latex, None),
   (sinc, sinc_latex, None),
   (xtimesbeta, xtimesbeta_latex, True),
   (xtimesbeta, xtimesbeta_latex_no_symbols, False),
@@ -63,5 +70,6 @@ def test_with_latex_to_str(func, expected_latex, math_symbol):
     latexified_function = with_latex(func)
   else:
     latexified_function = with_latex(math_symbol=math_symbol)(func)
+  print(str(latexified_function))
   assert str(latexified_function) == expected_latex
   assert expected_latex in latexified_function._repr_latex_()


### PR DESCRIPTION
Enable for example following case:

```
@latexify.with_latex
def foo(a):
 c = foo(a-1)
 return c
```

Also made changed test case a bit so that it is passing. 