### PR TITLE
Setup CI and fix tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -e .
     - name: Test with pytest
       run: |
         pytest

--- a/latexify/core.py
+++ b/latexify/core.py
@@ -52,10 +52,10 @@ class LatexifyVisitor(ast.NodeVisitor):
     return self.visit(node.body[0])
 
   def visit_FunctionDef(self, node):
-    name_str = r'\mathrm{' + str(node.name) + '}'
+    name_str = r'\operatorname{' + str(node.name) + '}'
     arg_strs = [self._parse_math_symbols(str(arg.arg)) for arg in node.args.args]
     body_str = self.visit(node.body[0])
-    return name_str + '(' + ', '.join(arg_strs) + r')\triangleq ' + body_str
+    return name_str + '(' + ', '.join(arg_strs) + r') \triangleq ' + body_str
 
   def visit_Return(self, node):
     return self.visit(node.value)
@@ -119,7 +119,12 @@ class LatexifyVisitor(ast.NodeVisitor):
   def visit_Name(self, node):
     return self._parse_math_symbols(str(node.id))
 
+  def visit_Constant(self, node):
+    # for python >= 3.8
+    return str(node.n)
+
   def visit_Num(self, node):
+    # for python < 3.8
     return str(node.n)
 
   def visit_UnaryOp(self, node):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -64,4 +64,4 @@ def test_with_latex_to_str(func, expected_latex, math_symbol):
   else:
     latexified_function = with_latex(math_symbol=math_symbol)(func)
   assert str(latexified_function) == expected_latex
-  assert latexified_function._repr_latex_() == expected_latex
+  assert latexified_function._repr_latex_() == r'$$ \displaystyle %s $$' % expected_latex


### PR DESCRIPTION
Hi @odashi 

I added CI by Github Actions https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions. Then, I fixed codes to pass `pytest` without errors and warnings. For recent deprecation in the ast module, see also https://docs.python.org/3/library/ast.html#ast.NodeVisitor
> Deprecated since version 3.8: Methods visit_Num(), visit_Str(), visit_Bytes(), visit_NameConstant() and visit_Ellipsis() are deprecated now and will not be called in future Python versions. Add the visit_Constant() method to handle all constant nodes.