### PR TITLE
Updated setuptools version from 0.0.7 to 0.0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def main():
 
   setuptools.setup(
     name='latexify-py',
-    version='0.0.7',
+    version='0.0.8',
     description='Generates LaTeX source from Python functions.',
     long_description=readme,
     long_description_type='text/markdown',


### PR DESCRIPTION
Causing [PyPi](https://pypi.org/project/latexify-py/#history) to use the older version of this package (0.0.7) that doesn't support Python 3.10.