### PR TITLE
Improve visit_Compare implementation

### DIFF
--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -38,7 +38,7 @@ def sinc(x):
 
 sinc_latex = (
     r"\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ "
-    r"x=0 \\ \frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array}"
+    r"{x = 0} \\ \frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array}"
     r" \right."
 )
 

--- a/src/latexify/latexify_visitor.py
+++ b/src/latexify/latexify_visitor.py
@@ -260,14 +260,13 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         ast.NotIn: r"\notin",
     }
 
-    def visit_Compare(self, node, action):  # pylint: disable=invalid-name
+    def visit_Compare(self, node: ast.Compare, action):  # pylint: disable=invalid-name
         """Visit a compare node."""
-        if len(node.ops) != 1:
-            raise SyntaxError("Multiple compares are not supported.")
-
         lhs = self.visit(node.left)
-        rhs = self.visit(node.comparators[0])
-        return f"{{{lhs} {self._compare_ops[type(node.ops[0])]} {rhs}}}"
+        ops = [self._compare_ops[type(x)] for x in node.ops]
+        rhs = [self.visit(x) for x in node.comparators]
+        ops_rhs = [f" {o} {r}" for o, r in zip(ops, rhs)]
+        return "{" + lhs + "".join(ops_rhs) + "}"
 
     def visit_BoolOp(self, node, action):  # pylint: disable=invalid-name
         logic_operator = (

--- a/src/latexify/latexify_visitor_test.py
+++ b/src/latexify/latexify_visitor_test.py
@@ -9,6 +9,7 @@ from latexify.latexify_visitor import LatexifyVisitor
 @pytest.mark.parametrize(
     "code,latex",
     [
+        # 1 comparator
         ("a == b", "{a = b}"),
         ("a > b", "{a > b}"),
         ("a >= b", r"{a \ge b}"),
@@ -19,16 +20,27 @@ from latexify.latexify_visitor import LatexifyVisitor
         ("a <= b", r"{a \le b}"),
         ("a != b", r"{a \ne b}"),
         ("a not in b", r"{a \notin b}"),
+        # 2 comparators
+        ("a == b == c", "{a = b = c}"),
+        ("a == b > c", "{a = b > c}"),
+        ("a == b >= c", r"{a = b \ge c}"),
+        ("a == b < c", "{a = b < c}"),
+        ("a == b <= c", r"{a = b \le c}"),
+        ("a > b == c", "{a > b = c}"),
+        ("a > b > c", "{a > b > c}"),
+        ("a > b >= c", r"{a > b \ge c}"),
+        ("a >= b == c", r"{a \ge b = c}"),
+        ("a >= b > c", r"{a \ge b > c}"),
+        ("a >= b >= c", r"{a \ge b \ge c}"),
+        ("a < b == c", "{a < b = c}"),
+        ("a < b < c", "{a < b < c}"),
+        ("a < b <= c", r"{a < b \le c}"),
+        ("a <= b == c", r"{a \le b = c}"),
+        ("a <= b < c", r"{a \le b < c}"),
+        ("a <= b <= c", r"{a \le b \le c}"),
     ],
 )
 def test_visit_compare(code: str, latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, ast.Compare)
     assert LatexifyVisitor().visit(tree) == latex
-
-
-def test_visit_compare_multiple() -> None:
-    tree = ast.parse("a < b < c").body[0].value
-    assert isinstance(tree, ast.Compare)
-    with pytest.raises(SyntaxError, match=r"^Multiple compares are not supported\.$"):
-        LatexifyVisitor().visit(tree)

--- a/src/latexify/latexify_visitor_test.py
+++ b/src/latexify/latexify_visitor_test.py
@@ -1,0 +1,34 @@
+"""Tests for latexify.latexify_visitor."""
+
+import ast
+import pytest
+
+from latexify.latexify_visitor import LatexifyVisitor
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("a == b", "{a = b}"),
+        ("a > b", "{a > b}"),
+        ("a >= b", r"{a \ge b}"),
+        ("a in b", r"{a \in b}"),
+        ("a is b", r"{a \equiv b}"),
+        ("a is not b", r"{a \not\equiv b}"),
+        ("a < b", "{a < b}"),
+        ("a <= b", r"{a \le b}"),
+        ("a != b", r"{a \ne b}"),
+        ("a not in b", r"{a \notin b}"),
+    ],
+)
+def test_visit_compare(code: str, latex: str) -> None:
+    tree = ast.parse(code).body[0].value
+    assert isinstance(tree, ast.Compare)
+    assert LatexifyVisitor().visit(tree) == latex
+
+
+def test_visit_compare_multiple() -> None:
+    tree = ast.parse("a < b < c").body[0].value
+    assert isinstance(tree, ast.Compare)
+    with pytest.raises(SyntaxError, match=r"^Multiple compares are not supported\.$"):
+        LatexifyVisitor().visit(tree)


### PR DESCRIPTION
This change introduces following changes:

- Add support for `is not`, `in`, `not in` operators. This includes cherrypicks of #59.
- Change the generated syntax from `a=b`, `a\op b` to `{a = b}`, `{a \op b}`.
- Support multiple comparators: `a == b == c` to `{a = b = c}`.