### PR TITLE
Remove action enum, and add Latexify specific exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -14,16 +14,7 @@
 """Latexify module-level constants"""
 
 import ast
-from typing import NamedTuple
 
-
-class Actions(NamedTuple):
-    """A class which holds supported actions as constants"""
-
-    SET_BOUNDS = "set_bounds"
-
-
-actions = Actions()
 
 PREFIXES = ["math", "numpy", "np"]
 

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -1,0 +1,27 @@
+"""Exceptions used in Latexify."""
+
+
+class LatexifyError(Exception):
+    """Base class of all Latexify exceptions.
+
+    Subclasses of this exception does not mean incorrect use of the library by the user,
+    but informs users that Latexify went into something worng during compiling the given
+    functions.
+    These functions are usually captured by the frontend functions (e.g., `with_latex`)
+    to prevent destroying the entire program.
+    Errors caused by the wrong inputs should raise built-in exceptions.
+    """
+
+    ...
+
+
+class LatexifyNotSupportedError(LatexifyError):
+    """Some subtree in the AST is not supported by the current implementation."""
+
+    ...
+
+
+class LatexifySyntaxError(LatexifyError):
+    """Some subtree in the AST has an incompatible form to be converted to LaTeX."""
+
+    ...

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -5,7 +5,7 @@ class LatexifyError(Exception):
     """Base class of all Latexify exceptions.
 
     Subclasses of this exception does not mean incorrect use of the library by the user,
-    but informs users that Latexify went into something worng during compiling the given
+    but informs users that Latexify went into something wrong during compiling the given
     functions.
     These functions are usually captured by the frontend functions (e.g., `with_latex`)
     to prevent destroying the entire program.

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -16,12 +16,21 @@ class LatexifyError(Exception):
 
 
 class LatexifyNotSupportedError(LatexifyError):
-    """Some subtree in the AST is not supported by the current implementation."""
+    """Some subtree in the AST is not supported by the current implementation.
+
+    This error is raised when the library discovered incompatible syntaxes due to lack
+    of the implementation. Possibly this error would be resolved in the future.
+    """
 
     ...
 
 
 class LatexifySyntaxError(LatexifyError):
-    """Some subtree in the AST has an incompatible form to be converted to LaTeX."""
+    """Some subtree in the AST is not supported.
+
+    This error is raised when the library discovered syntaxes that are not possible to
+    be processed anymore. This error is essential, and wouldn't be resolved in the
+    future.
+    """
 
     ...

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -108,7 +108,7 @@ class LatexifiedFunction:
     def _repr_html_(self):
         """IPython hook to display HTML visualization."""
         return (
-            '<font color="red">' + self._error + "</font>"
+            '<span style="color: red;">' + self._error + "</span>"
             if self._error is not None
             else None
         )

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -105,6 +105,14 @@ class LatexifiedFunction:
     def __str__(self):
         return self._latex if self._latex is not None else self._error
 
+    def _repr_html_(self):
+        """IPython hook to display HTML visualization."""
+        return (
+            '<font color="red">' + self._error + "</font>"
+            if self._error is not None
+            else None
+        )
+
     def _repr_latex_(self):
         """IPython hook to display LaTeX visualization."""
         return (

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import dill
 
-from latexify import latexify_visitor
+from latexify import exceptions, latexify_visitor
 from latexify.transformers.identifier_replacer import IdentifierReplacer
 
 
@@ -40,6 +40,9 @@ def get_latex(
 
     Returns:
         Generatee LaTeX description.
+
+    Raises:
+        latexify.exceptions.LatexifyError: Something went wrong during conversion.
     """
     try:
         source = inspect.getsource(fn)
@@ -67,9 +70,18 @@ def get_latex(
 class LatexifiedFunction:
     """Function with latex representation."""
 
+    _fn: Callable[..., Any]
+    _latex: str | None
+    _error: str | None
+
     def __init__(self, fn, **kwargs):
         self._fn = fn
-        self._str = get_latex(fn, **kwargs)
+        try:
+            self._latex = get_latex(fn, **kwargs)
+            self._error = None
+        except exceptions.LatexifyError as e:
+            self._latex = None
+            self._error = f"{type(e).__name__}: {str(e)}"
 
     @property
     def __doc__(self):
@@ -91,11 +103,15 @@ class LatexifiedFunction:
         return self._fn(*args)
 
     def __str__(self):
-        return self._str
+        return self._latex if self._latex is not None else self._error
 
     def _repr_latex_(self):
         """IPython hook to display LaTeX visualization."""
-        return r"$$ \displaystyle " + self._str + " $$"
+        return (
+            r"$$ \displaystyle " + self._latex + " $$"
+            if self._latex is not None
+            else self._error
+        )
 
 
 def with_latex(*args, **kwargs) -> Callable[[Callable[..., Any]], LatexifiedFunction]:

--- a/src/latexify/latexify_visitor.py
+++ b/src/latexify/latexify_visitor.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from latexify import constants
 from latexify import math_symbols
 from latexify import node_visitor_base
+from latexify import exceptions
 
 
 class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
@@ -45,8 +46,10 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
 
         self.assign_var = {}
 
-    def generic_visit(self, node, action):
-        return str(node)
+    def generic_visit(self, node, action) -> str:
+        raise exceptions.LatexifyNotSupportedError(
+            f"Unsupported AST: {type(node).__name__}"
+        )
 
     def visit_Module(self, node, action):  # pylint: disable=invalid-name
         return self.visit(node.body[0], "multi_lines")
@@ -78,7 +81,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
                 elif isinstance(el, ast.Return):
                     break
         if body_str == "":
-            raise ValueError("`return` missing")
+            raise exceptions.LatexifySyntaxError("`return` missing")
 
         return name_str, arg_strs, assign_vars, body_str
 
@@ -126,7 +129,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         def _decorated_lstr_and_arg(node, callee_str, lstr):
             """Decorates lstr and get its associated arguments"""
             if callee_str == "sum" and isinstance(node.args[0], ast.GeneratorExp):
-                generator_info = self.visit(node.args[0], constants.actions.SET_BOUNDS)
+                generator_info = self.visit(node.args[0], "set_bounds")
                 arg_str, comprehension = generator_info
                 var_comp, args_comp = comprehension
                 if len(args_comp) == 1:
@@ -293,14 +296,13 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         return latex + r", & \mathrm{otherwise} \end{array} \right."
 
     def visit_GeneratorExp_set_bounds(self, node):  # pylint: disable=invalid-name
-        action = constants.actions.SET_BOUNDS
         output = self.visit(node.elt)
         comprehensions = [
-            self.visit(generator, action) for generator in node.generators
+            self.visit(generator, "set_bounds") for generator in node.generators
         ]
         if len(comprehensions) == 1:
             return output, comprehensions[0]
-        raise TypeError(
+        raise exceptions.LatexifyNotSupportedError(
             "visit_GeneratorExp_sum() supports a single for clause"
             "but {} were given".format(len(comprehensions))
         )
@@ -314,6 +316,6 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
             args = [self.visit(arg) for arg in node.iter.args]
             if len(args) in (1, 2):
                 return var, args
-        raise TypeError(
+        raise exceptions.LatexifyNotSupportedError(
             "Comprehension for sum only supports range func " "with 1 or 2 args"
         )

--- a/src/latexify/latexify_visitor_test.py
+++ b/src/latexify/latexify_visitor_test.py
@@ -1,9 +1,21 @@
 """Tests for latexify.latexify_visitor."""
 
 import ast
+from latexify import exceptions
 import pytest
 
 from latexify.latexify_visitor import LatexifyVisitor
+
+
+def test_generic_visit() -> None:
+    class UnknownNode(ast.AST):
+        pass
+
+    with pytest.raises(
+        exceptions.LatexifyNotSupportedError,
+        match=r"^Unsupported AST: UnknownNode$",
+    ):
+        LatexifyVisitor().visit(UnknownNode())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Introduces following changes:

- Removes `Actions` enum and replace them to a raw string.
- Introduces `LatexifyError` and some subclasses.
- Introduces a behavior when `LatexifiedFunction` met some `LatexifyError`s.

# Details

`Actions` is eventually used as an identical stuff with strings. Maintaining this struct is no longer necessary as some other actions in `LatexifyVisitor` are defined as raw strings.

`LatexifyError` indicates internal errors of Latexify itself that can't be recovered by users.
`with_latexify` now captures this error to prevent destroying the runtime. Jupyter works as follows:

<img width="342" src="https://user-images.githubusercontent.com/1023695/198847518-13a567f9-d07b-4ee6-beac-bbc953798379.png">


# References

NA

# Blocked by

NA
