### PR TITLE
More refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -24,7 +24,7 @@ def solve(a, b, c):
 
 
 solve_latex = (
-    r"\mathrm{solve}(a, b, c) \triangleq " r"\frac{-b + \sqrt{b^{2} - 4ac}}{2a}"
+    r"\mathrm{solve}(a, b, c) \triangleq " r"\frac{-b + \sqrt{b^{{2}} - {4}ac}}{{2}a}"
 )
 
 
@@ -37,8 +37,8 @@ def sinc(x):
 
 
 sinc_latex = (
-    r"\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ "
-    r"{x = 0} \\ \frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array}"
+    r"\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} {1}, & \mathrm{if} \ "
+    r"{x = {0}} \\ \frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array}"
     r" \right."
 )
 
@@ -56,7 +56,7 @@ def sum_with_limit(n):
 
 
 sum_with_limit_latex = (
-    r"\mathrm{sum_with_limit}(n) \triangleq \sum_{i=0}^{n-1} \left({i^{2}}\right)"
+    r"\mathrm{sum_with_limit}(n) \triangleq \sum_{i=0}^{n-1} \left({i^{{2}}}\right)"
 )
 
 
@@ -66,7 +66,7 @@ def sum_with_limit_two_args(a, n):
 
 sum_with_limit_two_args_latex = (
     r"\mathrm{sum_with_limit_two_args}(a, n) "
-    r"\triangleq \sum_{i=a}^{n-1} \left({i^{2}}\right)"
+    r"\triangleq \sum_{i=a}^{n-1} \left({i^{{2}}}\right)"
 )
 
 
@@ -96,7 +96,7 @@ def test_nested_function():
     def nested(x):
         return 3 * x
 
-    assert get_latex(nested) == r"\mathrm{nested}(x) \triangleq 3x"
+    assert get_latex(nested) == r"\mathrm{nested}(x) \triangleq {3}x"
 
 
 def test_double_nested_function():
@@ -113,14 +113,14 @@ def test_use_raw_function_name():
     def foo_bar():
         return 42
 
-    assert str(with_latex(foo_bar)) == r"\mathrm{foo_bar}() \triangleq 42"
+    assert str(with_latex(foo_bar)) == r"\mathrm{foo_bar}() \triangleq {42}"
     assert (
         str(with_latex(foo_bar, use_raw_function_name=True))
-        == r"\mathrm{foo\_bar}() \triangleq 42"
+        == r"\mathrm{foo\_bar}() \triangleq {42}"
     )
     assert (
         str(with_latex(use_raw_function_name=True)(foo_bar))
-        == r"\mathrm{foo\_bar}() \triangleq 42"
+        == r"\mathrm{foo\_bar}() \triangleq {42}"
     )
 
 
@@ -129,9 +129,9 @@ def test_reduce_assignments():
         a = x + x
         return 3 * a
 
-    assert str(with_latex(f)) == r"a \triangleq x + x \\ \mathrm{f}(x) \triangleq 3a"
+    assert str(with_latex(f)) == r"a \triangleq x + x \\ \mathrm{f}(x) \triangleq {3}a"
 
-    latex_with_option = r"\mathrm{f}(x) \triangleq 3\left( x + x \right)"
+    latex_with_option = r"\mathrm{f}(x) \triangleq {3}\left( x + x \right)"
     assert str(with_latex(f, reduce_assignments=True)) == latex_with_option
     assert str(with_latex(reduce_assignments=True)(f)) == latex_with_option
 
@@ -143,12 +143,12 @@ def test_reduce_assignments_double():
         return 3 * b
 
     assert str(with_latex(f)) == (
-        r"a \triangleq x^{2} \\ b \triangleq a + a \\ \mathrm{f}(x) \triangleq 3b"
+        r"a \triangleq x^{{2}} \\ b \triangleq a + a \\ \mathrm{f}(x) \triangleq {3}b"
     )
 
     latex_with_option = (
         r"\mathrm{f}(x) \triangleq "
-        r"3\left( \left( x^{2} \right) + \left( x^{2} \right) \right)"
+        r"{3}\left( \left( x^{{2}} \right) + \left( x^{{2}} \right) \right)"
     )
     assert str(with_latex(f, reduce_assignments=True)) == latex_with_option
     assert str(with_latex(reduce_assignments=True)(f)) == latex_with_option

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -14,16 +14,7 @@
 """Latexify module-level constants"""
 
 import ast
-from typing import NamedTuple
 
-
-class Actions(NamedTuple):
-    """A class which holds supported actions as constants"""
-
-    SET_BOUNDS = "set_bounds"
-
-
-actions = Actions()
 
 PREFIXES = ["math", "numpy", "np"]
 

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -4,16 +4,12 @@
 class LatexifyError(Exception):
     """Base class of all Latexify exceptions.
 
-        Subclasses of this exception does not mean incorrect use of the library by the user,
-    <<<<<<< HEAD
-        but informs users that Latexify went into something worng during compiling the given
-    =======
-        but informs users that Latexify went into something wrong during compiling the given
-    >>>>>>> main
-        functions.
-        These functions are usually captured by the frontend functions (e.g., `with_latex`)
-        to prevent destroying the entire program.
-        Errors caused by the wrong inputs should raise built-in exceptions.
+    Subclasses of this exception does not mean incorrect use of the library by the user
+    at the interface level. These exceptions inform users that Latexify went into
+    something wrong during processing the given functions.
+    These exceptions are usually captured by the frontend functions (e.g., `with_latex`)
+    to prevent destroying the entire program.
+    Errors caused by wrong inputs should raise built-in exceptions.
     """
 
     ...

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -1,0 +1,27 @@
+"""Exceptions used in Latexify."""
+
+
+class LatexifyError(Exception):
+    """Base class of all Latexify exceptions.
+
+    Subclasses of this exception does not mean incorrect use of the library by the user,
+    but informs users that Latexify went into something worng during compiling the given
+    functions.
+    These functions are usually captured by the frontend functions (e.g., `with_latex`)
+    to prevent destroying the entire program.
+    Errors caused by the wrong inputs should raise built-in exceptions.
+    """
+
+    ...
+
+
+class LatexifyNotSupportedError(LatexifyError):
+    """Some subtree in the AST is not supported by the current implementation."""
+
+    ...
+
+
+class LatexifySyntaxError(LatexifyError):
+    """Some subtree in the AST has an incompatible form to be converted to LaTeX."""
+
+    ...

--- a/src/latexify/exceptions.py
+++ b/src/latexify/exceptions.py
@@ -16,12 +16,21 @@ class LatexifyError(Exception):
 
 
 class LatexifyNotSupportedError(LatexifyError):
-    """Some subtree in the AST is not supported by the current implementation."""
+    """Some subtree in the AST is not supported by the current implementation.
+
+    This error is raised when the library discovered incompatible syntaxes due to lack
+    of the implementation. Possibly this error would be resolved in the future.
+    """
 
     ...
 
 
 class LatexifySyntaxError(LatexifyError):
-    """Some subtree in the AST has an incompatible form to be converted to LaTeX."""
+    """Some subtree in the AST is not supported.
+
+    This error is raised when the library discovered syntaxes that are not possible to
+    be processed anymore. This error is essential, and wouldn't be resolved in the
+    future.
+    """
 
     ...

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-import ast
 from collections.abc import Callable
-import inspect
-import textwrap
 from typing import Any
 
-import dill
-
-from latexify import exceptions, latexify_visitor
+from latexify import exceptions, latexify_visitor, parser
 from latexify.transformers.identifier_replacer import IdentifierReplacer
 
 
@@ -44,16 +39,7 @@ def get_latex(
     Raises:
         latexify.exceptions.LatexifyError: Something went wrong during conversion.
     """
-    try:
-        source = inspect.getsource(fn)
-    except Exception:
-        # Maybe running on console.
-        source = dill.source.getsource(fn)
-
-    # Remove extra indentation so that ast.parse runs correctly.
-    source = textwrap.dedent(source)
-
-    tree = ast.parse(source)
+    tree = parser.parse_function(fn)
 
     if identifiers is not None:
         tree = IdentifierReplacer(identifiers).visit(tree)

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -108,7 +108,7 @@ class LatexifiedFunction:
     def _repr_html_(self):
         """IPython hook to display HTML visualization."""
         return (
-            '<font color="red">' + self._error + "</font>"
+            '<span style="color: red;">' + self._error + "</span>"
             if self._error is not None
             else None
         )

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -105,6 +105,14 @@ class LatexifiedFunction:
     def __str__(self):
         return self._latex if self._latex is not None else self._error
 
+    def _repr_html_(self):
+        """IPython hook to display HTML visualization."""
+        return (
+            '<font color="red">' + self._error + "</font>"
+            if self._error is not None
+            else None
+        )
+
     def _repr_latex_(self):
         """IPython hook to display LaTeX visualization."""
         return (

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import dill
 
-from latexify import latexify_visitor
+from latexify import exceptions, latexify_visitor
 from latexify.transformers.identifier_replacer import IdentifierReplacer
 
 
@@ -40,6 +40,9 @@ def get_latex(
 
     Returns:
         Generatee LaTeX description.
+
+    Raises:
+        latexify.exceptions.LatexifyError: Something went wrong during conversion.
     """
     try:
         source = inspect.getsource(fn)
@@ -67,9 +70,18 @@ def get_latex(
 class LatexifiedFunction:
     """Function with latex representation."""
 
+    _fn: Callable[..., Any]
+    _latex: str | None
+    _error: str | None
+
     def __init__(self, fn, **kwargs):
         self._fn = fn
-        self._str = get_latex(fn, **kwargs)
+        try:
+            self._latex = get_latex(fn, **kwargs)
+            self._error = None
+        except exceptions.LatexifyError as e:
+            self._latex = None
+            self._error = f"{type(e).__name__}: {str(e)}"
 
     @property
     def __doc__(self):
@@ -91,11 +103,15 @@ class LatexifiedFunction:
         return self._fn(*args)
 
     def __str__(self):
-        return self._str
+        return self._latex if self._latex is not None else self._error
 
     def _repr_latex_(self):
         """IPython hook to display LaTeX visualization."""
-        return r"$$ \displaystyle " + self._str + " $$"
+        return (
+            r"$$ \displaystyle " + self._latex + " $$"
+            if self._latex is not None
+            else self._error
+        )
 
 
 def with_latex(*args, **kwargs) -> Callable[[Callable[..., Any]], LatexifiedFunction]:

--- a/src/latexify/frontend_test.py
+++ b/src/latexify/frontend_test.py
@@ -15,5 +15,5 @@ def test_identifiers() -> None:
     }
 
     assert frontend.get_latex(very_long_name_function, identifiers=identifiers) == (
-        r"\mathrm{f}(x) \triangleq 3x"
+        r"\mathrm{f}(x) \triangleq {3}x"
     )

--- a/src/latexify/latexify_visitor.py
+++ b/src/latexify/latexify_visitor.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from latexify import constants
 from latexify import math_symbols
 from latexify import node_visitor_base
+from latexify import exceptions
 
 
 class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
@@ -45,8 +46,10 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
 
         self.assign_var = {}
 
-    def generic_visit(self, node, action):
-        return str(node)
+    def generic_visit(self, node, action) -> str:
+        raise exceptions.LatexifyNotSupportedError(
+            f"Unsupported AST: {type(node).__name__}"
+        )
 
     def visit_Module(self, node, action):  # pylint: disable=invalid-name
         return self.visit(node.body[0], "multi_lines")
@@ -78,7 +81,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
                 elif isinstance(el, ast.Return):
                     break
         if body_str == "":
-            raise ValueError("`return` missing")
+            raise exceptions.LatexifySyntaxError("`return` missing")
 
         return name_str, arg_strs, assign_vars, body_str
 
@@ -126,7 +129,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         def _decorated_lstr_and_arg(node, callee_str, lstr):
             """Decorates lstr and get its associated arguments"""
             if callee_str == "sum" and isinstance(node.args[0], ast.GeneratorExp):
-                generator_info = self.visit(node.args[0], constants.actions.SET_BOUNDS)
+                generator_info = self.visit(node.args[0], "set_bounds")
                 arg_str, comprehension = generator_info
                 var_comp, args_comp = comprehension
                 if len(args_comp) == 1:
@@ -293,14 +296,13 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         return latex + r", & \mathrm{otherwise} \end{array} \right."
 
     def visit_GeneratorExp_set_bounds(self, node):  # pylint: disable=invalid-name
-        action = constants.actions.SET_BOUNDS
         output = self.visit(node.elt)
         comprehensions = [
-            self.visit(generator, action) for generator in node.generators
+            self.visit(generator, "set_bounds") for generator in node.generators
         ]
         if len(comprehensions) == 1:
             return output, comprehensions[0]
-        raise TypeError(
+        raise exceptions.LatexifyNotSupportedError(
             "visit_GeneratorExp_sum() supports a single for clause"
             "but {} were given".format(len(comprehensions))
         )
@@ -314,6 +316,6 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
             args = [self.visit(arg) for arg in node.iter.args]
             if len(args) in (1, 2):
                 return var, args
-        raise TypeError(
+        raise exceptions.LatexifyNotSupportedError(
             "Comprehension for sum only supports range func " "with 1 or 2 args"
         )

--- a/src/latexify/latexify_visitor.py
+++ b/src/latexify/latexify_visitor.py
@@ -51,10 +51,10 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
             f"Unsupported AST: {type(node).__name__}"
         )
 
-    def visit_Module(self, node, action):  # pylint: disable=invalid-name
+    def visit_Module(self, node, action):
         return self.visit(node.body[0], "multi_lines")
 
-    def visit_FunctionDef(self, node, action):  # pylint: disable=invalid-name
+    def visit_FunctionDef(self, node, action):
         name_str = str(node.name)
         if self._use_raw_function_name:
             name_str = name_str.replace(r"_", r"\_")
@@ -108,22 +108,22 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         else:
             return rf"{node.targets[0].id} \triangleq {var} \\ "
 
-    def visit_Return(self, node, action):  # pylint: disable=invalid-name
+    def visit_Return(self, node, action):
         return self.visit(node.value)
 
-    def visit_Tuple(self, node, action):  # pylint: disable=invalid-name
+    def visit_Tuple(self, node, action):
         elts = [self.visit(i) for i in node.elts]
         return r"\left( " + r"\space,\space ".join(elts) + r"\right) "
 
-    def visit_List(self, node, action):  # pylint: disable=invalid-name
+    def visit_List(self, node, action):
         elts = [self.visit(i) for i in node.elts]
         return r"\left[ " + r"\space,\space ".join(elts) + r"\right] "
 
-    def visit_Set(self, node, action):  # pylint: disable=invalid-name
+    def visit_Set(self, node, action):
         elts = [self.visit(i) for i in node.elts]
         return r"\left\{ " + r"\space,\space ".join(elts) + r"\right\} "
 
-    def visit_Call(self, node, action):  # pylint: disable=invalid-name
+    def visit_Call(self, node, action):
         """Visit a call node."""
 
         def _decorated_lstr_and_arg(node, callee_str, lstr):
@@ -171,12 +171,12 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
             lstr, arg_str = _decorated_lstr_and_arg(node, callee_str, lstr)
             return lstr + arg_str + rstr
 
-    def visit_Attribute(self, node, action):  # pylint: disable=invalid-name
+    def visit_Attribute(self, node, action):
         vstr = self.visit(node.value)
         astr = str(node.attr)
         return vstr + "." + astr
 
-    def visit_Name(self, node, action):  # pylint: disable=invalid-name
+    def visit_Name(self, node, action):
         if self._reduce_assignments and node.id in self.assign_var.keys():
             return self.assign_var[node.id]
 
@@ -229,7 +229,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
     def visit_Ellipsis(self, node: ast.Ellipsis, action) -> str:
         return self.convert_constant(...)
 
-    def visit_UnaryOp(self, node, action):  # pylint: disable=invalid-name
+    def visit_UnaryOp(self, node, action):
         """Visit a unary op node."""
 
         def _wrap(child):
@@ -250,7 +250,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
             return reprs[type(node.op)]()
         return r"\mathrm{unknown\_uniop}(" + self.visit(node.operand) + ")"
 
-    def visit_BinOp(self, node, action):  # pylint: disable=invalid-name
+    def visit_BinOp(self, node, action):
         """Visit a binary op node."""
         priority = constants.BIN_OP_PRIORITY
 
@@ -302,7 +302,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         ast.NotIn: r"\notin",
     }
 
-    def visit_Compare(self, node: ast.Compare, action):  # pylint: disable=invalid-name
+    def visit_Compare(self, node: ast.Compare, action):
         """Visit a compare node."""
         lhs = self.visit(node.left)
         ops = [self._compare_ops[type(x)] for x in node.ops]
@@ -315,13 +315,13 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         ast.Or: r"\lor",
     }
 
-    def visit_BoolOp(self, node: ast.BoolOp, action):  # pylint: disable=invalid-name
+    def visit_BoolOp(self, node: ast.BoolOp, action):
         """Visit a BoolOp node."""
         values = [rf"\left( {self.visit(x)} \right)" for x in node.values]
         op = f" {self._bool_ops[type(node.op)]} "
         return "{" + op.join(values) + "}"
 
-    def visit_If(self, node, action):  # pylint: disable=invalid-name
+    def visit_If(self, node, action):
         """Visit an if node."""
         latex = r"\left\{ \begin{array}{ll} "
 
@@ -334,7 +334,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
         latex += self.visit(node)
         return latex + r", & \mathrm{otherwise} \end{array} \right."
 
-    def visit_GeneratorExp_set_bounds(self, node):  # pylint: disable=invalid-name
+    def visit_GeneratorExp_set_bounds(self, node):
         output = self.visit(node.elt)
         comprehensions = [
             self.visit(generator, "set_bounds") for generator in node.generators
@@ -383,7 +383,7 @@ class LatexifyVisitor(node_visitor_base.NodeVisitorBase):
 
         return f"{{{value}_{indices_str}}}"
 
-    def visit_comprehension_set_bounds(self, node):  # pylint: disable=invalid-name
+    def visit_comprehension_set_bounds(self, node):
         """Visit a comprehension node, which represents a for clause"""
         var = self.visit(node.target)
         if isinstance(node.iter, ast.Call):

--- a/src/latexify/latexify_visitor_test.py
+++ b/src/latexify/latexify_visitor_test.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import ast
-<<<<<<< HEAD
-from latexify import exceptions, test_utils
-=======
 from latexify import exceptions
->>>>>>> main
+from latexify import test_utils
+
 import pytest
 
-from latexify.latexify_visitor import LatexifyVisitor
+from latexify import latexify_visitor
 
 
 def test_generic_visit() -> None:
@@ -21,7 +19,7 @@ def test_generic_visit() -> None:
         exceptions.LatexifyNotSupportedError,
         match=r"^Unsupported AST: UnknownNode$",
     ):
-        LatexifyVisitor().visit(UnknownNode())
+        latexify_visitor.LatexifyVisitor().visit(UnknownNode())
 
 
 @pytest.mark.parametrize(
@@ -61,7 +59,7 @@ def test_generic_visit() -> None:
 def test_visit_compare(code: str, latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, ast.Compare)
-    assert LatexifyVisitor().visit(tree) == latex
+    assert latexify_visitor.LatexifyVisitor().visit(tree) == latex
 
 
 @pytest.mark.parametrize(
@@ -82,7 +80,7 @@ def test_visit_compare(code: str, latex: str) -> None:
 def test_visit_boolop(code: str, latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, ast.BoolOp)
-    assert LatexifyVisitor().visit(tree) == latex
+    assert latexify_visitor.LatexifyVisitor().visit(tree) == latex
 
 
 @test_utils.require_at_most(7)
@@ -107,7 +105,7 @@ def test_visit_boolop(code: str, latex: str) -> None:
 def test_visit_constant_lagacy(code: str, cls: type[ast.expr], latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, cls)
-    assert LatexifyVisitor().visit(tree) == latex
+    assert latexify_visitor.LatexifyVisitor().visit(tree) == latex
 
 
 @test_utils.require_at_least(8)
@@ -137,9 +135,9 @@ def test_visit_constant(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("x[0]", "{x_{0}}"),
-        ("x[0][1]", "{x_{0, 1}}"),
-        ("x[0][1][2]", "{x_{0, 1, 2}}"),
+        ("x[0]", "{x_{{0}}}"),
+        ("x[0][1]", "{x_{{0}, {1}}}"),
+        ("x[0][1][2]", "{x_{{0}, {1}, {2}}}"),
         ("x[foo]", "{x_{foo}}"),
         ("x[math.floor(x)]", r"{x_{\left\lfloor{x}\right\rfloor}}"),
     ],
@@ -147,4 +145,4 @@ def test_visit_constant(code: str, latex: str) -> None:
 def test_visit_subscript(code: str, latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, ast.Subscript)
-    assert LatexifyVisitor().visit(tree) == latex
+    assert latexify_visitor.LatexifyVisitor().visit(tree) == latex

--- a/src/latexify/latexify_visitor_test.py
+++ b/src/latexify/latexify_visitor_test.py
@@ -1,9 +1,21 @@
 """Tests for latexify.latexify_visitor."""
 
 import ast
+from latexify import exceptions
 import pytest
 
 from latexify.latexify_visitor import LatexifyVisitor
+
+
+def test_generic_visit() -> None:
+    class UnknownNode(ast.AST):
+        pass
+
+    with pytest.raises(
+        exceptions.LatexifyNotSupportedError,
+        match=r"^Unsupported AST: UnknownNode$",
+    ):
+        LatexifyVisitor().visit(UnknownNode())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

- Support all constant literals.
- Digits are wrapped by `{` and `}` so that the subscript operator works: $x_42$ --> $x_{42}$
  - This would insert unnecessarily many braces at this point, need further refactoring.
- Separate parsing strategy from `get_latex` to `parser.parse_function`.
- Test utilities:
  - Make `ast_equal` stricter.
  - Add `require_at_least/most` decorator to run tests on only specific Python verisons.
- Other trivial refactoring.

# Details

NA

# References

NA

# Blocked by

NA
