### PR TITLE
Support more expressions in sum and prod.

### DIFF
--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -89,7 +89,7 @@ def test_sum_with_limit_1arg() -> None:
         return sum(i**2 for i in range(n))
 
     latex = (
-        r"\mathrm{sum_with_limit}(n) = \sum_{i = 0}^{{n - 1}} \left({i^{{2}}}\right)"
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n - 1}} \left({i^{{2}}}\right)"
     )
     _check_function(sum_with_limit, latex)
 
@@ -109,7 +109,8 @@ def test_prod_with_limit_1arg() -> None:
         return math.prod(i**2 for i in range(n))
 
     latex = (
-        r"\mathrm{prod_with_limit}(n) = \prod_{i = 0}^{{n - 1}} \left({i^{{2}}}\right)"
+        r"\mathrm{prod_with_limit}(n) = "
+        r"\prod_{i = {0}}^{{n - 1}} \left({i^{{2}}}\right)"
     )
     _check_function(prod_with_limit, latex)
 

--- a/src/latexify/analyzers.py
+++ b/src/latexify/analyzers.py
@@ -12,7 +12,7 @@ from latexify import ast_utils, exceptions
 class RangeInfo:
     """Information of the range function."""
 
-    # Argument subtrees. These areguments could be shallow copies of the original
+    # Argument subtrees. These arguments could be shallow copies of the original
     # subtree.
     start: ast.expr
     stop: ast.expr

--- a/src/latexify/analyzers.py
+++ b/src/latexify/analyzers.py
@@ -32,6 +32,9 @@ def analyze_range(node: ast.Call) -> RangeInfo:
 
     Returns:
         RangeInfo extracted from `node`.
+
+    Raises:
+        LatexifySyntaxError: Analysis failed.
     """
     if not (
         isinstance(node.func, ast.Name)

--- a/src/latexify/analyzers.py
+++ b/src/latexify/analyzers.py
@@ -1,0 +1,61 @@
+"""Analyzer functions for specific subtrees."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+
+from latexify import ast_utils, exceptions
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class RangeInfo:
+    """Information of the range function."""
+
+    # Argument subtrees. These areguments could be shallow copies of the original
+    # subtree.
+    start: ast.expr
+    stop: ast.expr
+    step: ast.expr
+
+    # Integer representation of each argument, when it is possible.
+    start_int: int | None
+    stop_int: int | None
+    step_int: int | None
+
+
+def analyze_range(node: ast.Call) -> RangeInfo:
+    """Obtains RangeInfo from a Call subtree.
+
+    Args:
+        node: Subtree to be analyzed.
+
+    Returns:
+        RangeInfo extracted from `node`.
+    """
+    if not (
+        isinstance(node.func, ast.Name)
+        and node.func.id == "range"
+        and 1 <= len(node.args) <= 3
+    ):
+        raise exceptions.LatexifySyntaxError("Unsupported AST for analyze_range.")
+
+    num_args = len(node.args)
+
+    if num_args == 1:
+        start = ast_utils.make_constant(0)
+        stop = node.args[0]
+        step = ast_utils.make_constant(1)
+    else:
+        start = node.args[0]
+        stop = node.args[1]
+        step = node.args[2] if num_args == 3 else ast_utils.make_constant(1)
+
+    return RangeInfo(
+        start=start,
+        stop=stop,
+        step=step,
+        start_int=ast_utils.extract_int_or_none(start),
+        stop_int=ast_utils.extract_int_or_none(stop),
+        step_int=ast_utils.extract_int_or_none(step),
+    )

--- a/src/latexify/analyzers_test.py
+++ b/src/latexify/analyzers_test.py
@@ -1,0 +1,152 @@
+"""Tests for latexify.analyzers."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from latexify import analyzers, exceptions, test_utils
+
+
+@test_utils.require_at_least(8)
+@pytest.mark.parametrize(
+    "code,start,stop,step,start_int,stop_int,step_int",
+    [
+        (
+            "range(x)",
+            ast.Constant(value=0),
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Constant(value=1),
+            0,
+            None,
+            1,
+        ),
+        (
+            "range(123)",
+            ast.Constant(value=0),
+            ast.Constant(value=123),
+            ast.Constant(value=1),
+            0,
+            123,
+            1,
+        ),
+        (
+            "range(x, y)",
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Name(id="y", ctx=ast.Load()),
+            ast.Constant(value=1),
+            None,
+            None,
+            1,
+        ),
+        (
+            "range(123, y)",
+            ast.Constant(value=123),
+            ast.Name(id="y", ctx=ast.Load()),
+            ast.Constant(value=1),
+            123,
+            None,
+            1,
+        ),
+        (
+            "range(x, 123)",
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Constant(value=123),
+            ast.Constant(value=1),
+            None,
+            123,
+            1,
+        ),
+        (
+            "range(x, y, z)",
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Name(id="y", ctx=ast.Load()),
+            ast.Name(id="z", ctx=ast.Load()),
+            None,
+            None,
+            None,
+        ),
+        (
+            "range(123, y, z)",
+            ast.Constant(value=123),
+            ast.Name(id="y", ctx=ast.Load()),
+            ast.Name(id="z", ctx=ast.Load()),
+            123,
+            None,
+            None,
+        ),
+        (
+            "range(x, 123, z)",
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Constant(value=123),
+            ast.Name(id="z", ctx=ast.Load()),
+            None,
+            123,
+            None,
+        ),
+        (
+            "range(x, y, 123)",
+            ast.Name(id="x", ctx=ast.Load()),
+            ast.Name(id="y", ctx=ast.Load()),
+            ast.Constant(value=123),
+            None,
+            None,
+            123,
+        ),
+    ],
+)
+def test_analyze_range(
+    code: str,
+    start: ast.expr,
+    stop: ast.expr,
+    step: ast.expr | None,
+    start_int: int | None,
+    stop_int: int | None,
+    step_int: int | None,
+) -> None:
+    node = ast.parse(code).body[0].value
+    assert isinstance(node, ast.Call)
+
+    info = analyzers.analyze_range(node)
+
+    test_utils.assert_ast_equal(observed=info.start, expected=start)
+    test_utils.assert_ast_equal(observed=info.stop, expected=stop)
+    if step is not None:
+        test_utils.assert_ast_equal(observed=info.step, expected=step)
+    else:
+        assert info.step is None
+
+    def check_int(observed: int | None, expected: int | None) -> None:
+        if expected is not None:
+            assert observed == expected
+        else:
+            assert observed is None
+
+    check_int(observed=info.start_int, expected=start_int)
+    check_int(observed=info.stop_int, expected=stop_int)
+    check_int(observed=info.step_int, expected=step_int)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # Not a direct call
+        "__builtins__.range(x)",
+        'getattr(__builtins__, "range")(x)',
+        # Unsupported functions
+        "f(x)",
+        "iter(range(x))",
+        # Range with invalid arguments
+        "range()",
+        "range(x, y, z, w)",
+    ],
+)
+def test_analyze_range_invalid(code: str) -> None:
+    node = ast.parse(code).body[0].value
+    assert isinstance(node, ast.Call)
+
+    with pytest.raises(
+        exceptions.LatexifySyntaxError, match=r"^Unsupported AST for analyze_range\.$"
+    ):
+        analyzers.analyze_range(node)

--- a/src/latexify/ast_utils.py
+++ b/src/latexify/ast_utils.py
@@ -1,0 +1,88 @@
+"""Utilities to generate AST nodes."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from typing import Any
+
+
+def make_constant(value: Any) -> ast.expr:
+    """Generates a new Constant node.
+
+    Args:
+        value: Value of the node.
+
+    Returns:
+        Generated ast.Constant or its equivalent.
+
+    Raises:
+        ValueError: Unsupported value type.
+    """
+    if sys.version_info.minor < 8:
+        if value is None or value is False or value is True:
+            return ast.NameConstant(value=value)
+        if value is ...:
+            return ast.Ellipsis()
+        if isinstance(value, (int, float, complex)):
+            return ast.Num(n=value)
+        if isinstance(value, str):
+            return ast.Str(s=value)
+        if isinstance(value, bytes):
+            return ast.Bytes(s=value)
+    else:
+        if (
+            value is None
+            or value is ...
+            or isinstance(value, (bool, int, float, complex, str, bytes))
+        ):
+            return ast.Constant(value=value)
+
+    raise ValueError(f"Unsupported type to generate Constant: {type(value).__name__}")
+
+
+def extract_int_or_none(node: ast.expr) -> int | None:
+    """Extracts int constant from the given Constant node.
+
+    Args:
+        node: ast.Constant or its equivalent representing an int value.
+
+    Returns:
+        Extracted int value, or None if extraction failed.
+    """
+    if sys.version_info.minor < 8:
+        if (
+            isinstance(node, ast.Num)
+            and isinstance(node.n, int)
+            and not isinstance(node.n, bool)
+        ):
+            return node.n
+    else:
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, int)
+            and not isinstance(node.n, bool)
+        ):
+            return node.value
+
+    return None
+
+
+def extract_int(node: ast.expr) -> int:
+    """Extracts int constant from the given Constant node.
+
+    Args:
+        node: ast.Constant or its equivalent representing an int value.
+
+    Returns:
+        Extracted int value.
+
+    Raises:
+        ValueError: Not a subtree containing an int value.
+    """
+    value = extract_int_or_none(node)
+
+    if value is None:
+        raise ValueError(f"Unsupported node to extract int: {type(node).__name__}")
+
+    return value

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -1,0 +1,118 @@
+"""Tests for latexify.ast_utils."""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+import pytest
+
+from latexify import ast_utils
+from latexify import test_utils
+
+
+@test_utils.require_at_most(7)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, ast.NameConstant(value=None)),
+        (False, ast.NameConstant(value=False)),
+        (True, ast.NameConstant(value=True)),
+        (..., ast.Ellipsis()),
+        (123, ast.Num(n=123)),
+        (4.5, ast.Num(n=4.5)),
+        (6 + 7j, ast.Num(n=6 + 7j)),
+        ("foo", ast.Str(s="foo")),
+        (b"bar", ast.Bytes(s=b"bar")),
+    ],
+)
+def test_make_constant_legacy(value: Any, expected: ast.Constant) -> None:
+    test_utils.assert_ast_equal(
+        observed=ast_utils.make_constant(value),
+        expected=expected,
+    )
+
+
+@test_utils.require_at_least(8)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, ast.Constant(value=None)),
+        (False, ast.Constant(value=False)),
+        (True, ast.Constant(value=True)),
+        (..., ast.Constant(value=...)),
+        (123, ast.Constant(value=123)),
+        (4.5, ast.Constant(value=4.5)),
+        (6 + 7j, ast.Constant(value=6 + 7j)),
+        ("foo", ast.Constant(value="foo")),
+        (b"bar", ast.Constant(value=b"bar")),
+    ],
+)
+def test_make_constant(value: Any, expected: ast.Constant) -> None:
+    test_utils.assert_ast_equal(
+        observed=ast_utils.make_constant(value),
+        expected=expected,
+    )
+
+
+def test_make_constant_invalid() -> None:
+    with pytest.raises(ValueError, match=r"^Unsupported type to generate"):
+        ast_utils.make_constant(object())
+
+
+def test_extract_int_or_none() -> None:
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(-123)) == -123
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(0)) == 0
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(123)) == 123
+
+
+def test_extract_int_or_none_invalid() -> None:
+    # Not a subtree.
+    assert ast_utils.extract_int_or_none(123) is None
+
+    # Not a direct Constant node.
+    assert (
+        ast_utils.extract_int_or_none(ast.Expr(value=ast_utils.make_constant(123)))
+        is None
+    )
+
+    # Not a Constant node with int.
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(None)) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(True)) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(...)) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(123.0)) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(4 + 5j)) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant("123")) is None
+    assert ast_utils.extract_int_or_none(ast_utils.make_constant(b"123")) is None
+
+
+def test_extract_int() -> None:
+    assert ast_utils.extract_int(ast_utils.make_constant(-123)) == -123
+    assert ast_utils.extract_int(ast_utils.make_constant(0)) == 0
+    assert ast_utils.extract_int(ast_utils.make_constant(123)) == 123
+
+
+def test_extract_int_invalid() -> None:
+    # Not a subtree.
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(123)
+
+    # Not a direct Constant node.
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast.Expr(value=ast_utils.make_constant(123)))
+
+    # Not a Constant node with int.
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(None))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(True))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(...))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(123.0))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(4 + 5j))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant("123"))
+    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
+        ast_utils.extract_int(ast_utils.make_constant(b"123"))

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -42,6 +42,55 @@ def test_visit_functiondef_use_signature() -> None:
 
 
 @pytest.mark.parametrize(
+    "src_suffix,dest_suffix",
+    [
+        ("(x)", r" \left({x}\right)"),
+        ("([1, 2])", r" \left({\left[ {1}\space,\space {2}\right] }\right)"),
+        ("({1, 2})", r" \left({\left\{ {1}\space,\space {2}\right\} }\right)"),
+        ("(f(x))", r" \left({\mathrm{f}\left(x\right)}\right)"),
+        ("(i for i in x)", r"_{i \in x}^{} \left({i}\right)"),
+        (
+            "(i for i in [1, 2])",
+            r"_{i \in \left[ {1}\space,\space {2}\right] }^{} \left({i}\right)",
+        ),
+        (
+            "(i for i in {1, 2})",
+            r"_{i \in \left\{ {1}\space,\space {2}\right\} }^{} \left({i}\right)",
+        ),
+        ("(i for i in f(x))", r"_{i \in \mathrm{f}\left(x\right)}^{} \left({i}\right)"),
+        ("(i for i in range(n))", r"_{i = {0}}^{{n - 1}} \left({i}\right)"),
+        ("(i for i in range(3))", r"_{i = {0}}^{{2}} \left({i}\right)"),
+        ("(i for i in range(n, m))", r"_{i = n}^{{m - 1}} \left({i}\right)"),
+        ("(i for i in range(1, m))", r"_{i = {1}}^{{m - 1}} \left({i}\right)"),
+        ("(i for i in range(n, 3))", r"_{i = n}^{{2}} \left({i}\right)"),
+        (
+            "(i for i in range(n, m, k))",
+            r"_{i \in \mathrm{range}\left(n, m, k\right)}^{} \left({i}\right)",
+        ),
+    ],
+)
+def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
+    for src_fn, dest_fn in [("sum", r"\sum"), ("math.prod", r"\prod")]:
+        node = ast.parse(src_fn + src_suffix).body[0].value
+        assert isinstance(node, ast.Call)
+        assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
+
+
+def test_visit_call_sum_prod_multi_comprehension() -> None:
+    for fn_name in ["sum", "math.prod"]:
+        node = ast.parse(f"{fn_name}(i for y in x for i in y)").body[0].value
+        with pytest.raises(exceptions.LatexifyNotSupportedError, match="^Multi-clause"):
+            FunctionCodegen().visit(node)
+
+
+def test_visit_call_sum_prod_with_if() -> None:
+    for fn_name in ["sum", "math.prod"]:
+        node = ast.parse(f"{fn_name}(i for y in x if y == 0)").body[0].value
+        with pytest.raises(exceptions.LatexifyNotSupportedError, match="^If-clause"):
+            FunctionCodegen().visit(node)
+
+
+@pytest.mark.parametrize(
     "code,latex",
     [
         # 1 comparator

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -1,4 +1,4 @@
-"""Tests for latexify.latexify_visitor."""
+"""Tests for latexify.codegen.function_codegen."""
 
 from __future__ import annotations
 

--- a/src/latexify/test_utils.py
+++ b/src/latexify/test_utils.py
@@ -87,6 +87,7 @@ def ast_equal(observed: ast.AST, expected: ast.AST) -> bool:
                     for co, ce in zip(vo, ve)
                 )
             else:
+                assert type(vo) is type(ve)
                 assert vo == ve
 
     except (AssertionError, AttributeError):
@@ -121,18 +122,3 @@ AST does not match.
 observed={ast.dump(observed)}
 expected={ast.dump(expected)}
 """
-
-
-def make_num(value: int) -> ast.expr:
-    """Helper function to generate a node for number.
-
-    Args:
-        value: The value of the node.
-
-    Returns:
-        Generated AST.
-    """
-    if sys.version_info.minor < 8:
-        return ast.Num(n=value)
-    else:
-        return ast.Constant(value=value)

--- a/src/latexify/transformers/assignment_reducer_test.py
+++ b/src/latexify/transformers/assignment_reducer_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import ast
-from latexify import parser, test_utils
+from latexify import ast_utils, parser, test_utils
 
 from latexify.transformers.assignment_reducer import AssignmentReducer
 
@@ -54,7 +54,7 @@ def test_constant() -> None:
 
     expected = _make_ast(
         [
-            ast.Return(value=test_utils.make_num(0)),
+            ast.Return(value=ast_utils.make_constant(0)),
         ]
     )
     transformed = AssignmentReducer().visit(parser.parse_function(f))
@@ -70,7 +70,7 @@ def test_nested() -> None:
         [
             ast.Return(
                 value=ast.BinOp(
-                    left=test_utils.make_num(2),
+                    left=ast_utils.make_constant(2),
                     op=ast.Mult(),
                     right=ast.Name(id="x", ctx=ast.Load()),
                 )
@@ -91,10 +91,10 @@ def test_nested2() -> None:
         [
             ast.Return(
                 value=ast.BinOp(
-                    left=test_utils.make_num(3),
+                    left=ast_utils.make_constant(3),
                     op=ast.Add(),
                     right=ast.BinOp(
-                        left=test_utils.make_num(2),
+                        left=ast_utils.make_constant(2),
                         op=ast.Mult(),
                         right=ast.Name(id="x", ctx=ast.Load()),
                     ),
@@ -116,7 +116,7 @@ def test_overwrite() -> None:
         [
             ast.Return(
                 value=ast.BinOp(
-                    left=test_utils.make_num(3),
+                    left=ast_utils.make_constant(3),
                     op=ast.Add(),
                     right=ast.Name(id="x", ctx=ast.Load()),
                 )


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Supports following expressions in `sum` and `prod`:

<img width="388" src="https://user-images.githubusercontent.com/1023695/199956835-24a2fdfb-cab3-4160-8efe-872d21fe8fe9.png">

And introduces `analyzers` and `ast_utils` submodules.

# Details

- `ast_utils` provides trivial processors on AST. Currently it contains `make_constant` and `extract_int(_or_none)` functions.
- `analyzers` provides more complicated processors on AST, typically for analyzing a "snippet" in the code. Currently it contains `analyze_range` which analyzes the invocation of the `range` function and returns its information.
- `visit_Call` in `FunctionCodegen` utilizes `analyze_range` to check if the range information is available. If not (including unsupported `range` invocation), it generates a general form of `sum` or `prod` operations.

# References

NA

# Blocked by

NA
