### PR TITLE
fix: sub operate cause bracket error

### DIFF
--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -216,3 +216,11 @@ def test_reduce_assignments_with_if() -> None:
         ),
         reduce_assignments=True,
     )
+
+
+def test_sub_bracket() -> None:
+    def solve(a, b):
+        return ((a + b) - b) / (a - b) - (a + b) - (a - b) - (a * b)
+
+    latex = r"\mathrm{solve}(a, b) = \frac{a + b - b}{a - b} - (a + b) - (a - b) - ab"
+    _check_function(solve, latex)

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -229,12 +229,12 @@ class FunctionCodegen(ast.NodeVisitor):
         def _unwrap(child):
             return self.visit(child)
 
-        def _wrap(child):
+        def _wrap(child, force_use_bracket=False):
             latex = _unwrap(child)
             if isinstance(child, ast.BinOp):
                 cp = priority[type(child.op)] if type(child.op) in priority else 100
                 pp = priority[type(node.op)] if type(node.op) in priority else 100
-                if cp < pp:
+                if cp < pp or (cp == pp and force_use_bracket):
                     return "(" + latex + ")"
             return latex
 
@@ -242,7 +242,7 @@ class FunctionCodegen(ast.NodeVisitor):
         rhs = node.right
         reprs = {
             ast.Add: (lambda: _wrap(lhs) + " + " + _wrap(rhs)),
-            ast.Sub: (lambda: _wrap(lhs) + " - " + _wrap(rhs)),
+            ast.Sub: (lambda: _wrap(lhs) + " - " + _wrap(rhs, True)),
             ast.Mult: (lambda: _wrap(lhs) + _wrap(rhs)),
             ast.MatMult: (lambda: _wrap(lhs) + _wrap(rhs)),
             ast.Div: (lambda: r"\frac{" + _unwrap(lhs) + "}{" + _unwrap(rhs) + "}"),


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Because plus command and sub command has same priority, this will always cause a wrong brackest results.

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

# Details
![image](https://user-images.githubusercontent.com/33208530/200468122-13303282-1a5a-4181-a7f7-91af3898b085.png)

![image](https://user-images.githubusercontent.com/33208530/200468416-f3698948-986f-4879-ae1e-d84e907079e6.png)
