### PR TITLE
Support set operations.

### DIFF
--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -563,3 +563,33 @@ def test_visit_subscript(code: str, latex: str) -> None:
     tree = ast.parse(code).body[0].value
     assert isinstance(tree, ast.Subscript)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("a - b", r"a \setminus b"),
+        ("a & b", r"a \cap b"),
+        ("a ^ b", r"a \mathbin{\triangle} b"),
+        ("a | b", r"a \cup b"),
+    ],
+)
+def test_use_set_symbols_binop(code: str, latex: str) -> None:
+    tree = ast.parse(code).body[0].value
+    assert isinstance(tree, ast.BinOp)
+    assert function_codegen.FunctionCodegen(use_set_symbols=True).visit(tree) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("a < b", r"{a \subset b}"),
+        ("a <= b", r"{a \subseteq b}"),
+        ("a > b", r"{a \supset b}"),
+        ("a >= b", r"{a \supseteq b}"),
+    ],
+)
+def test_use_set_symbols_compare(code: str, latex: str) -> None:
+    tree = ast.parse(code).body[0].value
+    assert isinstance(tree, ast.Compare)
+    assert function_codegen.FunctionCodegen(use_set_symbols=True).visit(tree) == latex

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -20,6 +20,7 @@ def get_latex(
     use_math_symbols: bool = False,
     use_raw_function_name: bool = False,
     use_signature: bool = True,
+    use_set_symbols: bool = False,
 ) -> str:
     """Obtains LaTeX description from the function's source.
 
@@ -38,6 +39,7 @@ def get_latex(
             or convert it to subscript.
         use_signature: Whether to add the function signature before the expression or
             not.
+        use_set_symbols: Whether to use set symbols or not.
 
     Returns:
         Generatee LaTeX description.
@@ -59,6 +61,7 @@ def get_latex(
         use_math_symbols=use_math_symbols,
         use_raw_function_name=use_raw_function_name,
         use_signature=use_signature,
+        use_set_symbols=use_set_symbols,
     ).visit(tree)
 
 

--- a/src/latexify/frontend_test.py
+++ b/src/latexify/frontend_test.py
@@ -69,6 +69,18 @@ def test_get_latex_use_signature() -> None:
     assert frontend.get_latex(f, use_signature=True) == latex_with_flag
 
 
+def test_get_latex_use_set_symbols() -> None:
+    def f(x, y):
+        return x & y
+
+    latex_without_flag = r"\mathrm{f}(x, y) = x \mathbin{\&} y"
+    latex_with_flag = r"\mathrm{f}(x, y) = x \cap y"
+
+    assert frontend.get_latex(f) == latex_without_flag
+    assert frontend.get_latex(f, use_set_symbols=False) == latex_without_flag
+    assert frontend.get_latex(f, use_set_symbols=True) == latex_with_flag
+
+
 def test_function() -> None:
     def f(x):
         return x


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Supports following expressions:

<img width="470" alt="無題" src="https://user-images.githubusercontent.com/1023695/201504111-deff6453-9a6c-4571-a903-c6253f6ed273.png">

# Details

Add another typesets of BinOp and Compare for set operations, and switch it by the flag `use_set_symbols`. This flag is disabled by default.

Since the parser can't distinguish whether the expression represents a set or not, this flag affects the entire expression in the wrapped function.

# References

- #56

# Blocked by

NA
