### PR TITLE
fib(0) should be zero , not 1 as in sample code

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -101,7 +101,7 @@
     "@latexify.function\n",
     "def fib(x):\n",
     "    if x == 0:\n",
-    "        return 1\n",
+    "        return 0\n",
     "    elif x == 1:\n",
     "        return 1\n",
     "    else:\n",


### PR DESCRIPTION
fib(0) should be zero , not 1 as in sample code.

# Overview

fib(0) should be zero , not 1 as in sample code

# Details : 

just tested sample code and found answer incorrect because fib(0) = 1 in sample code, it should be zero instead.
e.g. from sample code Fib(0) = 1 but it should be zero
def fib(x):
    if x == 0:
        return 0 #instead of 1 as in orig code! 

# References

see example at https://www.mathsisfun.com/numbers/fibonacci-sequence.html or https://www.geeksforgeeks.org/python-program-for-program-for-fibonacci-numbers-2/ 


# Blocked by
N/A
