### PR TITLE
refactor: prefix trimming as a node transformer

### DIFF
--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -342,13 +342,6 @@ class FunctionCodegen(ast.NodeVisitor):
         # Function signature (possibly an expression).
         func_str = self.visit(node.func)
 
-        # Removes common prefixes: math.sqrt -> sqrt
-        # TODO(odashi): This process can be implemented as a NodeTransformer.
-        for prefix in constants.PREFIXES:
-            if func_str.startswith(f"{prefix}."):
-                func_str = func_str[len(prefix) + 1 :]
-                break
-
         # Obtains wrapper syntax: sqrt -> "\sqrt{" and "}"
         lstr, rstr = constants.BUILTIN_FUNCS.get(
             func_str,

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -162,7 +162,7 @@ def test_visit_setcomp(code: str, latex: str) -> None:
     ],
 )
 def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
-    for src_fn, dest_fn in [("sum", r"\sum"), ("math.prod", r"\prod")]:
+    for src_fn, dest_fn in [("sum", r"\sum"), ("prod", r"\prod")]:
         node = ast.parse(src_fn + src_suffix).body[0].value
         assert isinstance(node, ast.Call)
         assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
@@ -182,11 +182,11 @@ def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
         ),
         # 3 clauses
         (
-            "math.prod(i for y in x for i in y)",
+            "prod(i for y in x for i in y)",
             r"\prod_{y \in x}^{} \prod_{i \in y}^{} \left({i}\right)",
         ),
         (
-            "math.prod(i for y in x for z in y for i in z)",
+            "prod(i for y in x for z in y for i in z)",
             r"\prod_{y \in x}^{} \prod_{z \in y}^{} \prod_{i \in z}^{} "
             r"\left({i}\right)",
         ),
@@ -215,7 +215,7 @@ def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> No
     ],
 )
 def test_visit_call_sum_prod_with_if(src_suffix: str, dest_suffix: str) -> None:
-    for src_fn, dest_fn in [("sum", r"\sum"), ("math.prod", r"\prod")]:
+    for src_fn, dest_fn in [("sum", r"\sum"), ("prod", r"\prod")]:
         node = ast.parse(src_fn + src_suffix).body[0].value
         assert isinstance(node, ast.Call)
         assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
@@ -556,7 +556,7 @@ def test_visit_constant(code: str, latex: str) -> None:
         ("x[0][1]", "{x_{{0}, {1}}}"),
         ("x[0][1][2]", "{x_{{0}, {1}, {2}}}"),
         ("x[foo]", "{x_{foo}}"),
-        ("x[math.floor(x)]", r"{x_{\left\lfloor{x}\right\rfloor}}"),
+        ("x[floor(x)]", r"{x_{\left\lfloor{x}\right\rfloor}}"),
     ],
 )
 def test_visit_subscript(code: str, latex: str) -> None:

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-PREFIXES = ["math", "numpy", "np"]
+PREFIXES = {"math", "numpy", "np"}
 
 BUILTIN_FUNCS: dict[str, tuple[str, str]] = {
     "abs": (r"\left|{", r"}\right|"),

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -22,7 +22,7 @@ def get_latex(
     use_raw_function_name: bool = False,
     use_signature: bool = True,
     use_set_symbols: bool = False,
-    prefixes: set[str] = set(),
+    prefixes: set[str] | None = None,
 ) -> str:
     """Obtains LaTeX description from the function's source.
 
@@ -59,9 +59,10 @@ def get_latex(
         tree = transformers.IdentifierReplacer(identifiers).visit(tree)
     if reduce_assignments:
         tree = transformers.AssignmentReducer().visit(tree)
-    # assume that both prefixes and PREFIXES are sets.
     # merge and de-duplicate the prefix list.
-    merged_prefixes = set(constants.PREFIXES) | prefixes
+    if prefixes is None:
+        prefixes = set()
+    merged_prefixes = constants.PREFIXES | prefixes
     tree = transformers.PrefixTrimmer(merged_prefixes).visit(tree)
 
     # Generates LaTeX.

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -21,6 +21,7 @@ def get_latex(
     use_raw_function_name: bool = False,
     use_signature: bool = True,
     use_set_symbols: bool = False,
+    prefixes: list[str] | None = None,
 ) -> str:
     """Obtains LaTeX description from the function's source.
 
@@ -40,9 +41,11 @@ def get_latex(
         use_signature: Whether to add the function signature before the expression or
             not.
         use_set_symbols: Whether to use set symbols or not.
-
+        prefixes: Package prefixes to trim. If an alias is used, it should be in the list,
+            instead of the package itself. Example: for an `import numpy as np`, you pass
+            `prefixes=["np"]`
     Returns:
-        Generatee LaTeX description.
+        Generated LaTeX description.
 
     Raises:
         latexify.exceptions.LatexifyError: Something went wrong during conversion.
@@ -55,6 +58,8 @@ def get_latex(
         tree = transformers.IdentifierReplacer(identifiers).visit(tree)
     if reduce_assignments:
         tree = transformers.AssignmentReducer().visit(tree)
+    if prefixes is not None:
+        tree = transformers.PrefixTrimmer(prefixes).visit(tree)
 
     # Generates LaTeX.
     return codegen.FunctionCodegen(

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -10,6 +10,7 @@ from latexify import codegen
 from latexify import exceptions
 from latexify import parser
 from latexify import transformers
+from latexify import constants
 
 
 def get_latex(
@@ -21,7 +22,7 @@ def get_latex(
     use_raw_function_name: bool = False,
     use_signature: bool = True,
     use_set_symbols: bool = False,
-    prefixes: list[str] | None = None,
+    prefixes: set[str] = set(),
 ) -> str:
     """Obtains LaTeX description from the function's source.
 
@@ -41,9 +42,9 @@ def get_latex(
         use_signature: Whether to add the function signature before the expression or
             not.
         use_set_symbols: Whether to use set symbols or not.
-        prefixes: Package prefixes to trim. If an alias is used, it should be in the list,
+        prefixes: Package prefixes to trim. If an alias is used, it should be in the set,
             instead of the package itself. Example: for an `import numpy as np`, you pass
-            `prefixes=["np"]`
+            `prefixes={"np"}`
     Returns:
         Generated LaTeX description.
 
@@ -60,7 +61,7 @@ def get_latex(
         tree = transformers.AssignmentReducer().visit(tree)
     # assume that both prefixes and PREFIXES are sets.
     # merge and de-duplicate the prefix list.
-    merged_prefixes = constants.PREFIXES | prefixes
+    merged_prefixes = set(constants.PREFIXES) | prefixes
     tree = transformers.PrefixTrimmer(merged_prefixes).visit(tree)
 
     # Generates LaTeX.

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -58,8 +58,10 @@ def get_latex(
         tree = transformers.IdentifierReplacer(identifiers).visit(tree)
     if reduce_assignments:
         tree = transformers.AssignmentReducer().visit(tree)
-    if prefixes is not None:
-        tree = transformers.PrefixTrimmer(prefixes).visit(tree)
+    # assume that both prefixes and PREFIXES are sets.
+    # merge and de-duplicate the prefix list.
+    merged_prefixes = constants.PREFIXES | prefixes
+    tree = transformers.PrefixTrimmer(merged_prefixes).visit(tree)
 
     # Generates LaTeX.
     return codegen.FunctionCodegen(

--- a/src/latexify/transformers/__init__.py
+++ b/src/latexify/transformers/__init__.py
@@ -2,7 +2,9 @@
 
 from latexify.transformers import assignment_reducer
 from latexify.transformers import identifier_replacer
+from latexify.transformers import prefix_trimmer
 
 
 AssignmentReducer = assignment_reducer.AssignmentReducer
 IdentifierReplacer = identifier_replacer.IdentifierReplacer
+PrefixTrimmer = prefix_trimmer.PrefixTrimmer

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -9,8 +9,6 @@ class PrefixTrimmer(ast.NodeTransformer):
     """NodeTransformer to trim prefixes of identifiers.
 
     Example:
-        import math
-
         def foo(n):
             return math.sqrt(n)
 

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -27,7 +27,7 @@ class PrefixTrimmer(ast.NodeTransformer):
         """Initializer.
 
         Args:
-            prefixes: User defined prefixes.
+            prefixes: Set of prefixes to be trimmed.
         """
         self._prefixes = prefixes
 

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -12,14 +12,14 @@ class PrefixTrimmer(ast.NodeTransformer):
         def foo(n):
             return math.sqrt(n)
 
-        PrefixTrimmer(["math"]) will modify the AST of
+        PrefixTrimmer({"math"}) will modify the AST of
         the function above to below:
 
         def foo(n):
             return sqrt(n)
     """
 
-    def __init__(self, prefixes: list[str]):
+    def __init__(self, prefixes: set[str]):
         """Initializer.
 
         Args:
@@ -29,11 +29,30 @@ class PrefixTrimmer(ast.NodeTransformer):
 
     def visit_Call(self, node: ast.Call) -> ast.Call:
         """Visitor of Call."""
-        if (
-            isinstance(node.func, ast.Attribute)
-            and node.func.value.id in self._prefixes
-        ):
-            new_node_func = ast.Name(id=node.func.attr, ctx=node.func.ctx)
-            node.func = new_node_func
+        node_func = node.func
+        while isinstance(node_func, ast.Attribute):
+            node_func = node_func.value
+
+        # if outermost prefix matches any given prefix, loose
+        # the entire chain (if it's a chain)
+        if node_func.id in self._prefixes:
+            return ast.Call(
+                func=ast.Name(id=node.func.attr, ctx=node.func.ctx),
+                args=node.args,
+                keywords=node.keywords,
+            )
+
+        return node
+
+    def visit_Attribute(self, node: ast.Attribute) -> ast.Name | ast.Attribute:
+        """Visitor of Attribute."""
+        node_value = node.value
+        while isinstance(node_value, ast.Attribute):
+            node_value = node_value.value
+
+        # if outermost prefix matches any given prefix, loose
+        # the entire chain (if it's a chain)
+        if node_value.id in self._prefixes:
+            return ast.Name(id=node.value, ctx=node.value.ctx)
 
         return node

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -6,7 +6,7 @@ import ast
 
 
 class PrefixTrimmer(ast.NodeTransformer):
-    """NodeTransformer to trim package prefixes.
+    """NodeTransformer to trim prefixes of identifiers.
 
     Example:
         import math

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -31,7 +31,7 @@ class PrefixTrimmer(ast.NodeTransformer):
         """
         self._prefixes = prefixes
 
-    def visit_Call(self, node: ast.Call) -> ast.Name:
+    def visit_Call(self, node: ast.Call) -> ast.Call:
         """Visitor of Call."""
         if (
             isinstance(node.func, ast.Attribute)

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -17,8 +17,6 @@ class PrefixTrimmer(ast.NodeTransformer):
         PrefixTrimmer(["math"]) will modify the AST of
         the function above to below:
 
-        import math
-
         def foo(n):
             return sqrt(n)
     """

--- a/src/latexify/transformers/prefix_trimmer.py
+++ b/src/latexify/transformers/prefix_trimmer.py
@@ -1,0 +1,43 @@
+"""Transformer to trim package prefixes."""
+
+from __future__ import annotations
+
+import ast
+
+
+class PrefixTrimmer(ast.NodeTransformer):
+    """NodeTransformer to trim package prefixes.
+
+    Example:
+        import math
+
+        def foo(n):
+            return math.sqrt(n)
+
+        PrefixTrimmer(["math"]) will modify the AST of
+        the function above to below:
+
+        import math
+
+        def foo(n):
+            return sqrt(n)
+    """
+
+    def __init__(self, prefixes: list[str]):
+        """Initializer.
+
+        Args:
+            prefixes: User defined prefixes.
+        """
+        self._prefixes = prefixes
+
+    def visit_Call(self, node: ast.Call) -> ast.Name:
+        """Visitor of Call."""
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.value.id in self._prefixes
+        ):
+            new_node_func = ast.Name(id=node.func.attr, ctx=node.func.ctx)
+            node.func = new_node_func
+
+        return node

--- a/src/latexify/transformers/prefix_trimmer_test.py
+++ b/src/latexify/transformers/prefix_trimmer_test.py
@@ -1,0 +1,25 @@
+"""Tests for latexify.transformer.prefix_trimmer."""
+
+from __future__ import annotations
+
+import ast
+
+from latexify import test_utils
+from latexify.transformers.prefix_trimmer import PrefixTrimmer
+
+
+def test_correct_call_trim() -> None:
+    source = ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="math", ctx=ast.Load()), attr="sqrt", ctx=ast.Load()
+        ),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    expected = ast.Call(
+        func=ast.Name(id="sqrt", ctx=ast.Load()),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    transformed = PrefixTrimmer(["math"]).visit(source)
+    test_utils.assert_ast_equal(transformed, expected)

--- a/src/latexify/transformers/prefix_trimmer_test.py
+++ b/src/latexify/transformers/prefix_trimmer_test.py
@@ -54,11 +54,7 @@ def test_not_correct_trim() -> None:
         args=[ast.Name(id="x", ctx=ast.Load())],
         keywords=[],
     )
-    expected = ast.Call(
-        func=ast.Name(id="sqrt", ctx=ast.Load()),
-        args=[ast.Name(id="x", ctx=ast.Load())],
-        keywords=[],
-    )
+    expected = PrefixTrimmer({"math"}).visit(source)
     transformed = PrefixTrimmer({""}).visit(source)
     with pytest.raises(AssertionError):
         test_utils.assert_ast_equal(transformed, expected)
@@ -76,11 +72,7 @@ def test_not_correct_recursive_trim() -> None:
         args=[ast.Name(id="x", ctx=ast.Load())],
         keywords=[],
     )
-    expected = ast.Call(
-        func=ast.Name(id="lat", ctx=ast.Load()),
-        args=[ast.Name(id="x", ctx=ast.Load())],
-        keywords=[],
-    )
+    expected = PrefixTrimmer({"foo"}).visit(source)
     transformed = PrefixTrimmer({"lat"}).visit(source)
     with pytest.raises(AssertionError):
         test_utils.assert_ast_equal(transformed, expected)

--- a/src/latexify/transformers/prefix_trimmer_test.py
+++ b/src/latexify/transformers/prefix_trimmer_test.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import ast
-
+import pytest
 from latexify import test_utils
 from latexify.transformers.prefix_trimmer import PrefixTrimmer
 
 
-def test_correct_call_trim() -> None:
+def test_correct_trim() -> None:
     source = ast.Call(
         func=ast.Attribute(
             value=ast.Name(id="math", ctx=ast.Load()), attr="sqrt", ctx=ast.Load()
@@ -21,5 +21,66 @@ def test_correct_call_trim() -> None:
         args=[ast.Name(id="x", ctx=ast.Load())],
         keywords=[],
     )
-    transformed = PrefixTrimmer(["math"]).visit(source)
+    transformed = PrefixTrimmer({"math"}).visit(source)
     test_utils.assert_ast_equal(transformed, expected)
+
+
+def test_correct_recursive_trim() -> None:
+    source = ast.Call(
+        func=ast.Attribute(
+            value=ast.Attribute(
+                value=ast.Name(id="foo", ctx=ast.Load()), attr="bar", ctx=ast.Load()
+            ),
+            attr="lat",
+            ctx=ast.Load(),
+        ),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    expected = ast.Call(
+        func=ast.Name(id="lat", ctx=ast.Load()),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    transformed = PrefixTrimmer({"foo"}).visit(source)
+    test_utils.assert_ast_equal(transformed, expected)
+
+
+def test_not_correct_trim() -> None:
+    source = ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="math", ctx=ast.Load()), attr="sqrt", ctx=ast.Load()
+        ),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    expected = ast.Call(
+        func=ast.Name(id="sqrt", ctx=ast.Load()),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    transformed = PrefixTrimmer({""}).visit(source)
+    with pytest.raises(AssertionError):
+        test_utils.assert_ast_equal(transformed, expected)
+
+
+def test_not_correct_recursive_trim() -> None:
+    source = ast.Call(
+        func=ast.Attribute(
+            value=ast.Attribute(
+                value=ast.Name(id="foo", ctx=ast.Load()), attr="bar", ctx=ast.Load()
+            ),
+            attr="lat",
+            ctx=ast.Load(),
+        ),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    expected = ast.Call(
+        func=ast.Name(id="lat", ctx=ast.Load()),
+        args=[ast.Name(id="x", ctx=ast.Load())],
+        keywords=[],
+    )
+    transformed = PrefixTrimmer({"lat"}).visit(source)
+    with pytest.raises(AssertionError):
+        test_utils.assert_ast_equal(transformed, expected)


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview
Implemented the change proposed in issue #81.

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

# Details
Couldn't figure out a nice way of implementing automatic detection of used libraries and its aliases as discussed in #88, so in this implementation the user needs to pass them in a `set[str]` called `prefixes`. 

<!-- EDIT HERE IF ANY:
Write a detailed description of this change.
This section should include all changed introduced by this pull request.
It is also recommended to describe the backgrounds, approaches, and any other
information related to the pull request.
-->

# References
#81 #87 
<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

# Blocked by
NA
<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
