### PR TITLE
Addition / Subtraction Simplification for the stop parameter in sum / prod

### DIFF
--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -111,7 +111,7 @@ def test_sum_with_reducible_limit() -> None:
         return sum(i for i in range(n + 1))
     
     latex = (
-        r"\mathrm{sum_with_limit}(n) = \sum_{i = 0}^{n} \left({i}\right) "
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n}} \left({i}\right)"
     )
     _check_function(sum_with_limit, latex)
 
@@ -121,7 +121,7 @@ def test_sum_with_irreducible_limit() -> None:
         return sum(i for i in range(n * 3))
 
     latex = (
-        r"\mathrm{sum_with_limit}(n) = \sum_{i = 0}^{n * 3 - 1} \left({i}\right)"
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n {3} - 1}} \left({i}\right)"
     )
     _check_function(sum_with_limit, latex)
 
@@ -154,7 +154,7 @@ def test_prod_with_reducible_limits() -> None:
     
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
-        r"\prod_{i = 0}^{n - 2} \left({i}\right)"
+        r"\prod_{i = {0}}^{{n - {2}}} \left({i}\right)"
     )
     _check_function(prod_with_limit, latex)
 
@@ -165,10 +165,10 @@ def test_prod_with_irreducible_limit() -> None:
     
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
-        r"\prod_{i = 0}^{n * 3 - 1} \left({i}\right)"
+        r"\prod_{i = {0}}^{{n {3} - 1}} \left({i}\right)"
     )
     _check_function(prod_with_limit, latex)
-    
+
 
 def test_nested_function() -> None:
     def nested(x):

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -106,6 +106,26 @@ def test_sum_with_limit_2args() -> None:
     _check_function(sum_with_limit, latex)
 
 
+def test_sum_with_reducible_limit() -> None:
+    def sum_with_limit(n):
+        return sum(i for i in range(n + 1))
+    
+    latex = (
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = 0}^{n} \left({i}\right) "
+    )
+    _check_function(sum_with_limit, latex)
+
+
+def test_sum_with_irreducible_limit() -> None:
+    def sum_with_limit(n):
+        return sum(i for i in range(n * 3))
+
+    latex = (
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = 0}^{n * 3 - 1} \left({i}\right)"
+    )
+    _check_function(sum_with_limit, latex)
+
+
 def test_prod_with_limit_1arg() -> None:
     def prod_with_limit(n):
         return math.prod(i**2 for i in range(n))
@@ -127,6 +147,28 @@ def test_prod_with_limit_2args() -> None:
     )
     _check_function(prod_with_limit, latex)
 
+
+def test_prod_with_reducible_limits() -> None:
+    def prod_with_limit(n):
+        return math.prod(i for i in range(n - 1))
+    
+    latex = (
+        r"\mathrm{prod_with_limit}(n) = "
+        r"\prod_{i = 0}^{n - 2} \left({i}\right)"
+    )
+    _check_function(prod_with_limit, latex)
+
+
+def test_prod_with_irreducible_limit() -> None:
+    def prod_with_limit(n):
+        return math.prod(i for i in range(n * 3))
+    
+    latex = (
+        r"\mathrm{prod_with_limit}(n) = "
+        r"\prod_{i = 0}^{n * 3 - 1} \left({i}\right)"
+    )
+    _check_function(prod_with_limit, latex)
+    
 
 def test_nested_function() -> None:
     def nested(x):

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -109,10 +109,8 @@ def test_sum_with_limit_2args() -> None:
 def test_sum_with_reducible_limit() -> None:
     def sum_with_limit(n):
         return sum(i for i in range(n + 1))
-    
-    latex = (
-        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n}} \left({i}\right)"
-    )
+
+    latex = r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n}} \left({i}\right)"
     _check_function(sum_with_limit, latex)
 
 
@@ -151,7 +149,7 @@ def test_prod_with_limit_2args() -> None:
 def test_prod_with_reducible_limits() -> None:
     def prod_with_limit(n):
         return math.prod(i for i in range(n - 1))
-    
+
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
         r"\prod_{i = {0}}^{{n - {2}}} \left({i}\right)"
@@ -162,7 +160,7 @@ def test_prod_with_reducible_limits() -> None:
 def test_prod_with_irreducible_limit() -> None:
     def prod_with_limit(n):
         return math.prod(i for i in range(n * 3))
-    
+
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
         r"\prod_{i = {0}}^{{n {3} - 1}} \left({i}\right)"

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -110,7 +110,10 @@ def test_sum_with_reducible_limit() -> None:
     def sum_with_limit(n):
         return sum(i for i in range(n + 1))
 
-    latex = r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n}} \left({i}\right)"
+    latex = (
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n}} "
+        r"\mathopen{}\left({i}\mathclose{}\right)"
+    )
     _check_function(sum_with_limit, latex)
 
 
@@ -119,7 +122,8 @@ def test_sum_with_irreducible_limit() -> None:
         return sum(i for i in range(n * 3))
 
     latex = (
-        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n {3} - 1}} \left({i}\right)"
+        r"\mathrm{sum_with_limit}(n) = \sum_{i = {0}}^{{n {3} - 1}} "
+        r"\mathopen{}\left({i}\mathclose{}\right)"
     )
     _check_function(sum_with_limit, latex)
 
@@ -152,7 +156,7 @@ def test_prod_with_reducible_limits() -> None:
 
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
-        r"\prod_{i = {0}}^{{n - {2}}} \left({i}\right)"
+        r"\prod_{i = {0}}^{{n - {2}}} \mathopen{}\left({i}\mathclose{}\right)"
     )
     _check_function(prod_with_limit, latex)
 
@@ -163,7 +167,7 @@ def test_prod_with_irreducible_limit() -> None:
 
     latex = (
         r"\mathrm{prod_with_limit}(n) = "
-        r"\prod_{i = {0}}^{{n {3} - 1}} \left({i}\right)"
+        r"\prod_{i = {0}}^{{n {3} - 1}} \mathopen{}\left({i}\mathclose{}\right)"
     )
     _check_function(prod_with_limit, latex)
 

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -588,14 +588,18 @@ class FunctionCodegen(ast.NodeVisitor):
                         upper = "{" + self.visit(range_info.stop.left) + "}"
                     else:
                         reduced_constant = ast.Constant(range_info.stop.right.value - 1)
-                        new_node = ast.BinOp(range_info.stop.left, range_info.stop.op, reduced_constant)
-                        upper = "{" + self.visit(new_node) + "}" 
+                        new_node = ast.BinOp(
+                            range_info.stop.left, range_info.stop.op, reduced_constant
+                        )
+                        upper = "{" + self.visit(new_node) + "}"
                 else:
                     if range_info.stop.right.value == -1:
                         upper = "{" + self.visit(range_info.stop.left) + "}"
                     else:
                         reduced_constant = ast.Constant(range_info.stop.right.value + 1)
-                        new_node = ast.BinOp(range_info.stop.left, range_info.stop.op, reduced_constant)
+                        new_node = ast.BinOp(
+                            range_info.stop.left, range_info.stop.op, reduced_constant
+                        )
                         upper = "{" + self.visit(new_node) + "}"
             else:
                 upper = "{" + self.visit(range_info.stop) + " - 1}"

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import sys
 import dataclasses
 from typing import Any
 
@@ -536,6 +537,48 @@ class FunctionCodegen(ast.NodeVisitor):
         latex += self.visit(node)
         return latex + r", & \mathrm{otherwise} \end{array} \right."
 
+    def _reduce_stop_parameter(self, node: ast.BinOp) -> str:
+        # ast.Constant class is added in Python 3.8
+        # ast.Num is the relevant node type in previous versions
+        if sys.version_info.minor < 8:
+            if isinstance(node.right, ast.Num):
+                if isinstance(node.op, ast.Add):
+                    if node.right.n == 1:
+                        upper = "{" + self.visit(node.left) + "}"
+                    else:
+                        reduced_constant = ast.Num(node.right.n - 1)
+                        new_node = ast.BinOp(node.left, node.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}"
+                else:
+                    if node.right.n == -1:
+                        upper = "{" + self.visit(node.left) + "}"
+                    else:
+                        reduced_constant = ast.Num(node.right.n + 1)
+                        new_node = ast.BinOp(node.left, node.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}"
+            else:
+                upper = "{" + self.visit(node) + "}"
+        else:
+            if isinstance(node.right, ast.Constant):
+                if isinstance(node.op, ast.Add):
+                    if node.right.value == 1:
+                        upper = "{" + self.visit(node.left) + "}"
+                    else:
+                        reduced_constant = ast.Constant(node.right.value - 1)
+                        new_node = ast.BinOp(node.left, node.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}"
+                else:
+                    if node.right.value == -1:
+                        upper = "{" + self.visit(node.left) + "}"
+                    else:
+                        reduced_constant = ast.Constant(node.right.value + 1)
+                        new_node = ast.BinOp(node.left, node.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}"
+            else:
+                upper = "{" + self.visit(node) + "}"
+
+        return upper
+
     def _get_sum_prod_range(self, node: ast.comprehension) -> tuple[str, str] | None:
         """Helper to process range(...) for sum and prod functions.
 
@@ -578,29 +621,10 @@ class FunctionCodegen(ast.NodeVisitor):
 
         if range_info.stop_int is None:
             # special processing needed if range_info.stop involves addition or subtraction
-            if (
-                isinstance(range_info.stop, ast.BinOp)
-                and isinstance(range_info.stop.op, (ast.Add, ast.Sub))
-                and isinstance(range_info.stop.right, ast.Constant)
+            if isinstance(range_info.stop, ast.BinOp) and isinstance(
+                range_info.stop.op, (ast.Add, ast.Sub)
             ):
-                if isinstance(range_info.stop.op, ast.Add):
-                    if range_info.stop.right.value == 1:
-                        upper = "{" + self.visit(range_info.stop.left) + "}"
-                    else:
-                        reduced_constant = ast.Constant(range_info.stop.right.value - 1)
-                        new_node = ast.BinOp(
-                            range_info.stop.left, range_info.stop.op, reduced_constant
-                        )
-                        upper = "{" + self.visit(new_node) + "}"
-                else:
-                    if range_info.stop.right.value == -1:
-                        upper = "{" + self.visit(range_info.stop.left) + "}"
-                    else:
-                        reduced_constant = ast.Constant(range_info.stop.right.value + 1)
-                        new_node = ast.BinOp(
-                            range_info.stop.left, range_info.stop.op, reduced_constant
-                        )
-                        upper = "{" + self.visit(new_node) + "}"
+                upper = self._reduce_stop_parameter(range_info.stop)
             else:
                 upper = "{" + self.visit(range_info.stop) + " - 1}"
         else:

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -620,7 +620,7 @@ class FunctionCodegen(ast.NodeVisitor):
             lower_rhs = f"{{{range_info.start_int}}}"
 
         if range_info.stop_int is None:
-            # special processing needed if range_info.stop involves addition or subtraction
+            # use special processing if range_info.stop involves addition or subtraction
             if isinstance(range_info.stop, ast.BinOp) and isinstance(
                 range_info.stop.op, (ast.Add, ast.Sub)
             ):

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -577,7 +577,28 @@ class FunctionCodegen(ast.NodeVisitor):
             lower_rhs = f"{{{range_info.start_int}}}"
 
         if range_info.stop_int is None:
-            upper = "{" + self.visit(range_info.stop) + " - 1}"
+            # special processing needed if range_info.stop involves addition or subtraction
+            if (
+                isinstance(range_info.stop, ast.BinOp)
+                and isinstance(range_info.stop.op, (ast.Add, ast.Sub))
+                and isinstance(range_info.stop.right, ast.Constant)
+            ):
+                if isinstance(range_info.stop.op, ast.Add):
+                    if range_info.stop.right.value == 1:
+                        upper = "{" + self.visit(range_info.stop.left) + "}"
+                    else:
+                        reduced_constant = ast.Constant(range_info.stop.right.value - 1)
+                        new_node = ast.BinOp(range_info.stop.left, range_info.stop.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}" 
+                else:
+                    if range_info.stop.right.value == -1:
+                        upper = "{" + self.visit(range_info.stop.left) + "}"
+                    else:
+                        reduced_constant = ast.Constant(range_info.stop.right.value + 1)
+                        new_node = ast.BinOp(range_info.stop.left, range_info.stop.op, reduced_constant)
+                        upper = "{" + self.visit(new_node) + "}"
+            else:
+                upper = "{" + self.visit(range_info.stop) + " - 1}"
         else:
             upper = f"{{{range_info.stop_int - 1}}}"
 

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -228,6 +228,15 @@ def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
             "math.prod(i for i in range(n-1))",
             r"\prod_{i = {0}}^{{n - {2}}} \mathopen{}\left({i}\mathclose{}\right)",
         ),
+        # reduce stop parameter
+        (
+            "sum(i for i in range(n+1))",
+            r"\sum_{i = {0}}^{{n}} \mathopen{}\left({i}\mathclose{}\right)",
+        ),
+        (
+            "math.prod(i for i in range(n-1))",
+            r"\prod_{i = {0}}^{{n - {2}}} \mathopen{}\left({i}\mathclose{}\right)",
+        ),
     ],
 )
 def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> None:

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -219,6 +219,12 @@ def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
             r"\prod_{y \in x}^{} \prod_{z \in y}^{} \prod_{i \in z}^{} "
             r"\mathopen{}\left({i}\mathclose{}\right)",
         ),
+        # reduce stop parameter
+        ("sum(i for i in range(n+1))", r"\sum_{i = {0}}^{{n}} \left({i}\right)"),
+        (
+            "math.prod(i for i in range(n-1))",
+            r"\prod_{i = {0}}^{{n - {2}}} \left({i}\right)",
+        ),
     ],
 )
 def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> None:

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -220,10 +220,13 @@ def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
             r"\mathopen{}\left({i}\mathclose{}\right)",
         ),
         # reduce stop parameter
-        ("sum(i for i in range(n+1))", r"\sum_{i = {0}}^{{n}} \left({i}\right)"),
+        (
+            "sum(i for i in range(n+1))",
+            r"\sum_{i = {0}}^{{n}} \mathopen{}\left({i}\mathclose{}\right)",
+        ),
         (
             "math.prod(i for i in range(n-1))",
-            r"\prod_{i = {0}}^{{n - {2}}} \left({i}\right)",
+            r"\prod_{i = {0}}^{{n - {2}}} \mathopen{}\left({i}\mathclose{}\right)",
         ),
     ],
 )


### PR DESCRIPTION
<Reducing addition and subtraction in sum and prod stop parameter>

# Overview

This PR addresses issue #74. 

# Details

## Implementation 
First check the `stop` parameter of `range_info` is `ast.BinOp` and represents an addition or subtraction. If so, the minus one is applied to `BinOp.right` and a new `ast.BinOp` node is created. Then the existing visit function is leveraged to create the needed Latex.

Note the special cases `+ 1 - 1` and `- (-1) - 1` for which only `BinOp.left` is kept.

Added test cases to `regression_test.py`. Please let me know if these are more appropriate elsewhere (e.g. `function_codegen_test.py`)

## Caveats 
- `n+1-1` can be reduced to `n` but `1+n-1` cannot. This is because `range(1+n)` is unlikely and unusual. Support for this can be easily added if desired
- chained additions and subtractions cannot be fully reduced. `n + 3+4-1` will become `n+3+3` not `n+6`. This is in line with how other chained BinOps are currently handled and may be addressed in a future issue

## Questions
The implementation is slightly verbose and perhaps should be written as a separate function. Might other future PRs need this similar functionality?

# References
Issue #74 

