### PR TITLE
Add isort module to checks script and Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,17 @@ jobs:
           python -m pip install pyproject-flake8
       - name: Check
         run: pflake8 -v src
+  isort:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install isort
+    - name: Check
+      run: isort -v src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,16 @@ jobs:
       - name: Check
         run: pflake8 -v src
   isort:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install isort
-    - name: Check
-      run: python -m isort -v src
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install isort
+      - name: Check
+        run: python -m isort -v src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install isort
     - name: Check
-      run: isort -v src
+      run: python -m isort -v src

--- a/checks.sh
+++ b/checks.sh
@@ -4,3 +4,4 @@ set -eoux pipefail
 python -m pytest src -vv
 python -m black --check src
 python -m pflake8 src
+python -m isort -v src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pyproject-flake8>=5.0",
     "pytest>=7.1",
     "twine>=4.0",
+    "isort>=5.10",
 ]
 
 [project.urls]

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import math
+from collections.abc import Callable
 from typing import Any
 
 from latexify import frontend

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -7,8 +7,7 @@ from typing import Any
 
 import pytest
 
-from latexify import ast_utils
-from latexify import test_utils
+from latexify import ast_utils, test_utils
 
 
 @test_utils.require_at_most(7)

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -3,15 +3,11 @@
 from __future__ import annotations
 
 import ast
-import sys
 import dataclasses
+import sys
 from typing import Any
 
-from latexify import analyzers
-from latexify import constants
-from latexify import math_symbols
-from latexify import exceptions
-
+from latexify import analyzers, constants, exceptions, math_symbols
 
 # Precedences of operators for BoolOp, BinOp, UnaryOp, and Compare nodes.
 # Note that this value affects only the appearance of surrounding parentheses for each

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import ast
-from latexify import exceptions
-from latexify import test_utils
 
 import pytest
 
+from latexify import exceptions, test_utils
 from latexify.codegen import FunctionCodegen, function_codegen
 
 

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import Any
-import warnings
 
-from latexify import codegen
-from latexify import exceptions
-from latexify import parser
-from latexify import transformers
+from latexify import codegen, exceptions, parser, transformers
 
 
 def get_latex(

--- a/src/latexify/parser.py
+++ b/src/latexify/parser.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import ast
 import inspect
 import textwrap
+from collections.abc import Callable
 from typing import Any
 
 import dill

--- a/src/latexify/parser_test.py
+++ b/src/latexify/parser_test.py
@@ -6,8 +6,7 @@ import ast
 
 import pytest
 
-from latexify import exceptions, parser
-from latexify import test_utils
+from latexify import exceptions, parser, test_utils
 
 
 def test_parse_function_with_posonlyargs() -> None:

--- a/src/latexify/test_utils.py
+++ b/src/latexify/test_utils.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import ast
-from collections.abc import Callable
 import functools
 import sys
+from collections.abc import Callable
 from typing import cast
 
 

--- a/src/latexify/transformers/__init__.py
+++ b/src/latexify/transformers/__init__.py
@@ -1,8 +1,6 @@
 """Package latexify.transformers."""
 
-from latexify.transformers import assignment_reducer
-from latexify.transformers import identifier_replacer
-
+from latexify.transformers import assignment_reducer, identifier_replacer
 
 AssignmentReducer = assignment_reducer.AssignmentReducer
 IdentifierReplacer = identifier_replacer.IdentifierReplacer

--- a/src/latexify/transformers/assignment_reducer_test.py
+++ b/src/latexify/transformers/assignment_reducer_test.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import ast
-from latexify import ast_utils, parser, test_utils
 
+from latexify import ast_utils, parser, test_utils
 from latexify.transformers.assignment_reducer import AssignmentReducer
 
 


### PR DESCRIPTION
# Overview

Add isort module to check python import order and format identically

# Details

- add isort module to development environment
- using isort to refactor the code
- add isort check to `checks.sh`
- add isort step to Github CI




