### PR TITLE
Update typo in parameters.md 

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -74,7 +74,7 @@ f
 
 $$\mathrm{quadratic\_solution}(a, b, c) = \frac{-b + \sqrt{b^{{2}} - {4} a c}}{{2} a}$$
 
-(note that GitHub's LaTeX renderrer does not process underscores correctly.)
+(note that GitHub's LaTeX renderer does not process underscores correctly.)
 
 ## `use_set_symbols: bool`
 


### PR DESCRIPTION
Fixed typo in parameters.md

# Overview

Fixed typo in "use_raw_function_name: bool" section