### PR TITLE
Allow docstring in function definition

### DIFF
--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -279,3 +279,12 @@ def test_sub_bracket() -> None:
         r"a - b \mathclose{}\right) - a b"
     )
     _check_function(solve, latex)
+
+
+def test_docstring_allowed() -> None:
+    def solve(x):
+        """The identity function."""
+        return x
+
+    latex = r"\mathrm{solve}(x) = x"
+    _check_function(solve, latex)

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -288,3 +288,14 @@ def test_docstring_allowed() -> None:
 
     latex = r"\mathrm{solve}(x) = x"
     _check_function(solve, latex)
+
+
+def test_multiple_constants_allowed() -> None:
+    def solve(x):
+        """The identity function."""
+        123
+        True
+        return x
+
+    latex = r"\mathrm{solve}(x) = x"
+    _check_function(solve, latex)

--- a/src/latexify/ast_utils.py
+++ b/src/latexify/ast_utils.py
@@ -41,6 +41,31 @@ def make_constant(value: Any) -> ast.expr:
     raise ValueError(f"Unsupported type to generate Constant: {type(value).__name__}")
 
 
+def is_constant(node: ast.AST) -> bool:
+    """Checks if the node is a constant.
+
+    Args:
+        node: The node to examine.
+
+    Returns:
+        True if the node is a constant, False otherwise.
+    """
+    if sys.version_info.minor < 8:
+        if isinstance(
+            node,
+            (ast.Bytes, ast.Constant, ast.Ellipsis, ast.NameConstant, ast.Num, ast.Str),
+        ):
+            return True
+    else:
+        if isinstance(node, ast.Constant):
+            return True
+
+    if isinstance(node, ast.Expr):
+        return is_constant(node.value)
+
+    return False
+
+
 def extract_int_or_none(node: ast.expr) -> int | None:
     """Extracts int constant from the given Constant node.
 

--- a/src/latexify/ast_utils.py
+++ b/src/latexify/ast_utils.py
@@ -51,19 +51,12 @@ def is_constant(node: ast.AST) -> bool:
         True if the node is a constant, False otherwise.
     """
     if sys.version_info.minor < 8:
-        if isinstance(
+        return isinstance(
             node,
             (ast.Bytes, ast.Constant, ast.Ellipsis, ast.NameConstant, ast.Num, ast.Str),
-        ):
-            return True
+        )
     else:
-        if isinstance(node, ast.Constant):
-            return True
-
-    if isinstance(node, ast.Expr):
-        return is_constant(node.value)
-
-    return False
+        return isinstance(node, ast.Constant)
 
 
 def extract_int_or_none(node: ast.expr) -> int | None:

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -69,11 +69,11 @@ def test_make_constant_invalid() -> None:
         (ast.NameConstant(value=None), True),
         (ast.Num(n=123), True),
         (ast.Str(s="baz"), True),
-        (ast.Expr(value=ast.Num(456)), True),
+        (ast.Expr(value=ast.Num(456)), False),
         (ast.Global("qux"), False),
     ],
 )
-def test_is_constant_legacy(value: Any, expected: ast.Constant) -> None:
+def test_is_constant_legacy(value: ast.AST, expected: bool) -> None:
     assert ast_utils.is_constant(value) is expected
 
 
@@ -82,11 +82,11 @@ def test_is_constant_legacy(value: Any, expected: ast.Constant) -> None:
     "value,expected",
     [
         (ast.Constant("foo"), True),
-        (ast.Expr(value=ast.Constant(123)), True),
+        (ast.Expr(value=ast.Constant(123)), False),
         (ast.Global("bar"), False),
     ],
 )
-def test_is_constant(value: Any, expected: ast.Constant) -> None:
+def test_is_constant(value: ast.AST, expected: bool) -> None:
     assert ast_utils.is_constant(value) is expected
 
 

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -59,6 +59,37 @@ def test_make_constant_invalid() -> None:
         ast_utils.make_constant(object())
 
 
+@test_utils.require_at_most(7)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (ast.Bytes(s=b"foo"), True),
+        (ast.Constant("bar"), True),
+        (ast.Ellipsis(), True),
+        (ast.NameConstant(value=None), True),
+        (ast.Num(n=123), True),
+        (ast.Str(s="baz"), True),
+        (ast.Expr(value=ast.Num(456)), True),
+        (ast.Global("qux"), False),
+    ],
+)
+def test_is_constant_legacy(value: Any, expected: ast.Constant) -> None:
+    assert ast_utils.is_constant(value) is expected
+
+
+@test_utils.require_at_least(8)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (ast.Constant("foo"), True),
+        (ast.Expr(value=ast.Constant(123)), True),
+        (ast.Global("bar"), False),
+    ],
+)
+def test_is_constant(value: Any, expected: ast.Constant) -> None:
+    assert ast_utils.is_constant(value) is expected
+
+
 def test_extract_int_or_none() -> None:
     assert ast_utils.extract_int_or_none(ast_utils.make_constant(-123)) == -123
     assert ast_utils.extract_int_or_none(ast_utils.make_constant(0)) == 0

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -7,7 +7,7 @@ import dataclasses
 import sys
 from typing import Any
 
-from latexify import analyzers, constants, exceptions, math_symbols
+from latexify import analyzers, ast_utils, constants, exceptions, math_symbols
 
 # Precedences of operators for BoolOp, BinOp, UnaryOp, and Compare nodes.
 # Note that this value affects only the appearance of surrounding parentheses for each
@@ -252,13 +252,9 @@ class FunctionCodegen(ast.NodeVisitor):
         body_strs: list[str] = []
 
         # Assignment statements (if any): x = ...
-        for i, child in enumerate(node.body[:-1]):
-            # Allow docstrings
-            if (
-                i == 0
-                and isinstance(child, ast.Expr)
-                and isinstance(child.value, ast.Constant)
-            ):
+        for child in node.body[:-1]:
+            # Allow constants
+            if ast_utils.is_constant(child):
                 continue
 
             if not isinstance(child, ast.Assign):

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -252,7 +252,15 @@ class FunctionCodegen(ast.NodeVisitor):
         body_strs: list[str] = []
 
         # Assignment statements (if any): x = ...
-        for child in node.body[:-1]:
+        for i, child in enumerate(node.body[:-1]):
+            # Allow docstrings
+            if (
+                i == 0
+                and isinstance(child, ast.Expr)
+                and isinstance(child.value, ast.Constant)
+            ):
+                continue
+
             if not isinstance(child, ast.Assign):
                 raise exceptions.LatexifyNotSupportedError(
                     "Codegen supports only Assign nodes in multiline functions, "

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -253,7 +253,7 @@ class FunctionCodegen(ast.NodeVisitor):
 
         # Assignment statements (if any): x = ...
         for child in node.body[:-1]:
-            if ast_utils.is_constant(child):
+            if isinstance(child, ast.Expr) and ast_utils.is_constant(child.value):
                 continue
 
             if not isinstance(child, ast.Assign):

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -253,7 +253,6 @@ class FunctionCodegen(ast.NodeVisitor):
 
         # Assignment statements (if any): x = ...
         for child in node.body[:-1]:
-            # Allow constants
             if ast_utils.is_constant(child):
                 continue
 

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -37,11 +37,15 @@ def f(x):
 
 
 def test_visit_functiondef_ignore_docstring() -> None:
-    tree = ast.parse(textwrap.dedent("""
+    tree = ast.parse(
+        textwrap.dedent(
+            """
         def f(x):
             '''docstring'''
             return x
-        """)).body[0]
+        """
+        )
+    ).body[0]
     assert isinstance(tree, ast.FunctionDef)
 
     latex = r"\mathrm{f}(x) = x"
@@ -49,13 +53,17 @@ def test_visit_functiondef_ignore_docstring() -> None:
 
 
 def test_visit_functiondef_ignore_multiple_constants() -> None:
-    tree = ast.parse(textwrap.dedent("""
+    tree = ast.parse(
+        textwrap.dedent(
+            """
         def f(x):
             '''docstring'''
             3
             True
             return x
-        """)).body[0]
+            """
+        )
+    ).body[0]
     assert isinstance(tree, ast.FunctionDef)
 
     latex = r"\mathrm{f}(x) = x"

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import textwrap
 
 import pytest
 
@@ -36,25 +37,27 @@ def f(x):
 
 
 def test_visit_functiondef_ignore_docstring() -> None:
-    tree = ast.parse(
-        """
-def f(x):
-    '''docstring'''
-    return x"""
-    )
+    tree = ast.parse(textwrap.dedent("""
+        def f(x):
+            '''docstring'''
+            return x
+        """)).body[0]
+    assert isinstance(tree, ast.FunctionDef)
+
     latex = r"\mathrm{f}(x) = x"
     assert FunctionCodegen().visit(tree) == latex
 
 
 def test_visit_functiondef_ignore_multiple_constants() -> None:
-    tree = ast.parse(
-        """
-def f(x):
-    '''docstring'''
-    3
-    True
-    return x"""
-    )
+    tree = ast.parse(textwrap.dedent("""
+        def f(x):
+            '''docstring'''
+            3
+            True
+            return x
+        """)).body[0]
+    assert isinstance(tree, ast.FunctionDef)
+
     latex = r"\mathrm{f}(x) = x"
     assert FunctionCodegen().visit(tree) == latex
 

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -50,13 +50,34 @@ def test_visit_functiondef_ignore_docstring() -> None:
             defaults=[],
         ),
         body=[
-            ast.Expr(ast_utils.make_constant("""docstring""")),
+            ast.Expr(ast_utils.make_constant("docstring")),
             ast.Return(value=ast.Name(id="x", ctx=ast.Load())),
         ],
         decorator_list=[],
     )
-    latex_with_flag = r"\mathrm{f}(x) = x"
-    assert FunctionCodegen().visit(tree) == latex_with_flag
+    latex = r"\mathrm{f}(x) = x"
+    assert FunctionCodegen().visit(tree) == latex
+
+
+def test_visit_functiondef_ignore_multiple_constants() -> None:
+    tree = ast.FunctionDef(
+        name="f",
+        args=ast.arguments(
+            args=[ast.arg(arg="x")],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
+        ),
+        body=[
+            ast.Expr(ast_utils.make_constant("docstring" "")),
+            ast.Expr(ast_utils.make_constant(3)),
+            ast.Expr(ast_utils.make_constant(True)),
+            ast.Return(value=ast.Name(id="x", ctx=ast.Load())),
+        ],
+        decorator_list=[],
+    )
+    latex = r"\mathrm{f}(x) = x"
+    assert FunctionCodegen().visit(tree) == latex
 
 
 @pytest.mark.parametrize(

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -24,11 +24,15 @@ def test_generic_visit() -> None:
 
 def test_visit_functiondef_use_signature() -> None:
     tree = ast.parse(
-        """
-def f(x):
-    return x
-    """
-    )
+        textwrap.dedent(
+            """
+        def f(x):
+            return x
+            """
+        )
+    ).body[0]
+    assert isinstance(tree, ast.FunctionDef)
+
     latex_without_flag = "x"
     latex_with_flag = r"\mathrm{f}(x) = x"
     assert FunctionCodegen().visit(tree) == latex_with_flag
@@ -43,7 +47,7 @@ def test_visit_functiondef_ignore_docstring() -> None:
         def f(x):
             '''docstring'''
             return x
-        """
+            """
         )
     ).body[0]
     assert isinstance(tree, ast.FunctionDef)

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -6,7 +6,7 @@ import ast
 
 import pytest
 
-from latexify import exceptions, test_utils
+from latexify import ast_utils, exceptions, test_utils
 from latexify.codegen import FunctionCodegen, function_codegen
 
 
@@ -38,6 +38,25 @@ def test_visit_functiondef_use_signature() -> None:
     assert FunctionCodegen().visit(tree) == latex_with_flag
     assert FunctionCodegen(use_signature=False).visit(tree) == latex_without_flag
     assert FunctionCodegen(use_signature=True).visit(tree) == latex_with_flag
+
+
+def test_visit_functiondef_ignore_docstring() -> None:
+    tree = ast.FunctionDef(
+        name="f",
+        args=ast.arguments(
+            args=[ast.arg(arg="x")],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
+        ),
+        body=[
+            ast.Expr(ast_utils.make_constant("""docstring""")),
+            ast.Return(value=ast.Name(id="x", ctx=ast.Load())),
+        ],
+        decorator_list=[],
+    )
+    latex_with_flag = r"\mathrm{f}(x) = x"
+    assert FunctionCodegen().visit(tree) == latex_with_flag
 
 
 @pytest.mark.parametrize(

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -6,7 +6,7 @@ import ast
 
 import pytest
 
-from latexify import ast_utils, exceptions, test_utils
+from latexify import exceptions, test_utils
 from latexify.codegen import FunctionCodegen, function_codegen
 
 
@@ -22,16 +22,11 @@ def test_generic_visit() -> None:
 
 
 def test_visit_functiondef_use_signature() -> None:
-    tree = ast.FunctionDef(
-        name="f",
-        args=ast.arguments(
-            args=[ast.arg(arg="x")],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[],
-        ),
-        body=[ast.Return(value=ast.Name(id="x", ctx=ast.Load()))],
-        decorator_list=[],
+    tree = ast.parse(
+        """
+def f(x):
+    return x
+    """
     )
     latex_without_flag = "x"
     latex_with_flag = r"\mathrm{f}(x) = x"
@@ -41,40 +36,24 @@ def test_visit_functiondef_use_signature() -> None:
 
 
 def test_visit_functiondef_ignore_docstring() -> None:
-    tree = ast.FunctionDef(
-        name="f",
-        args=ast.arguments(
-            args=[ast.arg(arg="x")],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[],
-        ),
-        body=[
-            ast.Expr(ast_utils.make_constant("docstring")),
-            ast.Return(value=ast.Name(id="x", ctx=ast.Load())),
-        ],
-        decorator_list=[],
+    tree = ast.parse(
+        """
+def f(x):
+    '''docstring'''
+    return x"""
     )
     latex = r"\mathrm{f}(x) = x"
     assert FunctionCodegen().visit(tree) == latex
 
 
 def test_visit_functiondef_ignore_multiple_constants() -> None:
-    tree = ast.FunctionDef(
-        name="f",
-        args=ast.arguments(
-            args=[ast.arg(arg="x")],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[],
-        ),
-        body=[
-            ast.Expr(ast_utils.make_constant("docstring" "")),
-            ast.Expr(ast_utils.make_constant(3)),
-            ast.Expr(ast_utils.make_constant(True)),
-            ast.Return(value=ast.Name(id="x", ctx=ast.Load())),
-        ],
-        decorator_list=[],
+    tree = ast.parse(
+        """
+def f(x):
+    '''docstring'''
+    3
+    True
+    return x"""
     )
     latex = r"\mathrm{f}(x) = x"
     assert FunctionCodegen().visit(tree) == latex


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

Allows a docstring to be defined at the top of the function.

# Details

<!-- EDIT HERE IF ANY:
Write a detailed description of this change.
This section should include all changed introduced by this pull request.
It is also recommended to describe the backgrounds, approaches, and any other
information related to the pull request.
-->

Docstrings (multiline strings) are represented as an `ast.Expr(ast.Constant)`.
When validating that all child statements (minus the last one) in a function definition are of the class `ast.Assign`, we make an exception if the first one is an `ast.Expr(ast.Constant)`.

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

https://github.com/google/latexify_py/issues/104