### PR TITLE
NDArray support

### DIFF
--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -369,7 +369,7 @@ class FunctionCodegen(ast.NodeVisitor):
         def generate_matrix_from_array(data: list[list[str]]) -> str:
             """Helper to generate a bmatrix environment."""
             contents = r" \\ ".join(" & ".join(row) for row in data)
-            return r"\begin{bmatrix} " + contents + r"\end{bmatrix}"
+            return r"\begin{bmatrix} " + contents + r" \end{bmatrix}"
 
         arg = node.args[0]
         if not isinstance(arg, ast.List) or not arg.elts:
@@ -380,7 +380,7 @@ class FunctionCodegen(ast.NodeVisitor):
 
         if not isinstance(row0, ast.List):
             # Maybe 1 x N array
-            return generate_matrix_from_array([self.visit(x) for x in arg.elts])
+            return generate_matrix_from_array([[self.visit(x) for x in arg.elts]])
 
         if not row0.elts:
             # No columns

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -334,18 +334,84 @@ class FunctionCodegen(ast.NodeVisitor):
         wrapped = [r"\mathopen{}\left( " + s + r" \mathclose{}\right)" for s in conds]
         return r" \land ".join(wrapped)
 
+    def _generate_sum_prod(self, node: ast.Call) -> str | None:
+        """Generates sum/prod expression.
+
+        Args:
+            node: ast.Call node containing the sum/prod invocation.
+
+        Returns:
+            Generated LaTeX, or None if the node has unsupported syntax.
+        """
+        if not isinstance(node.args[0], ast.GeneratorExp):
+            return None
+
+        name = ast_utils.extract_function_name_or_none(node)
+        assert name is not None
+
+        elt, scripts = self._get_sum_prod_info(node.args[0])
+        scripts_str = [rf"\{name}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
+        return (
+            " ".join(scripts_str)
+            + rf" \mathopen{{}}\left({{{elt}}}\mathclose{{}}\right)"
+        )
+
+    def _generate_matrix(self, node: ast.Call) -> str | None:
+        """Generates matrix expression.
+
+        Args:
+            node: ast.Call node containing the ndarray invocation.
+
+        Returns:
+            Generated LaTeX, or None if the node has unsupported syntax.
+        """
+
+        def generate_matrix_from_array(data: list[list[str]]) -> str:
+            """Helper to generate a bmatrix environment."""
+            contents = r" \\ ".join(" & ".join(row) for row in data)
+            return r"\begin{bmatrix} " + contents + r"\end{bmatrix}"
+
+        arg = node.args[0]
+        if not isinstance(arg, ast.List) or not arg.elts:
+            # Not an array or no rows
+            return None
+
+        row0 = arg.elts[0]
+
+        if not isinstance(row0, ast.List):
+            # Maybe 1 x N array
+            return generate_matrix_from_array([self.visit(x) for x in arg.elts])
+
+        if not row0.elts:
+            # No columns
+            return None
+
+        ncols = len(row0.elts)
+
+        if not all(
+            isinstance(row, ast.List) and len(row.elts) == ncols for row in arg.elts
+        ):
+            # Length mismatch
+            return None
+
+        return generate_matrix_from_array(
+            [[self.visit(x) for x in row.elts] for row in arg.elts]
+        )
+
     def visit_Call(self, node: ast.Call) -> str:
         """Visit a call node."""
         func_name = ast_utils.extract_function_name_or_none(node)
 
-        # Special processing for sum and prod.
-        if func_name in ("sum", "prod") and isinstance(node.args[0], ast.GeneratorExp):
-            elt, scripts = self._get_sum_prod_info(node.args[0])
-            scripts_str = [rf"\{func_name}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
-            return (
-                " ".join(scripts_str)
-                + rf" \mathopen{{}}\left({{{elt}}}\mathclose{{}}\right)"
-            )
+        # Special treatments for some functions.
+        if func_name in ("sum", "prod"):
+            special_latex = self._generate_sum_prod(node)
+        elif func_name in ("array", "ndarray"):
+            special_latex = self._generate_matrix(node)
+        else:
+            special_latex = None
+
+        if special_latex is not None:
+            return special_latex
 
         # Function signature (possibly an expression).
         default_func_str = self.visit(node.func)
@@ -356,52 +422,8 @@ class FunctionCodegen(ast.NodeVisitor):
             (default_func_str + r"\mathopen{}\left(", r"\mathclose{}\right)"),
         )
 
-<<<<<<< HEAD
-=======
-        if func_str in ("ndarray", "array"):
-            arg = node.args[0]
-            if not isinstance(arg, ast.List) or not arg.elts:
-                return None
-
-            row0 = arg.elts[0]
-
-            if not isinstance(row0, ast.List):
-                return self._generate_ndarray([self.visit(x) for x in arg.elts])
-
-            if not row0.elts:
-                return None
-
-            nCols = len(row0.elts)
-
-            if not all(
-                isinstance(row, ast.List) and len(row.elts) == nCols for row in arg.elts
-            ):
-                return None
-
-            return self._generate_ndarray(
-                [[self.visit(x) for x in row.elts] for row in arg.elts]
-            )
-
-        if func_str in ("sum", "prod") and isinstance(node.args[0], ast.GeneratorExp):
-            elt, scripts = self._get_sum_prod_info(node.args[0])
-            scripts_str = [rf"\{func_str}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
-            return " ".join(scripts_str) + rf" \left({{{elt}}}\right)"
-
->>>>>>> aaa/np-ndarray
         arg_strs = [self.visit(arg) for arg in node.args]
         return lstr + ", ".join(arg_strs) + rstr
-
-    def _generate_ndarray(self, data: list[list[str]]) -> str:
-        """Generates a latex matrix from a 2d list of strings.
-
-        Args:
-            data: A 2d list of strings.
-
-        Returns:
-            Generated LaTeX expression.
-        """
-        contents = r" \\ ".join(" & ".join(row) for row in data)
-        return r"\begin{bmatrix} " + contents + r" \end{bmatrix}"
 
     def visit_Attribute(self, node: ast.Attribute) -> str:
         vstr = self.visit(node.value)

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -749,18 +749,38 @@ def test_use_set_symbols_compare(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("np.ndarray([1])", r"\begin{bmatrix} 1 \end{bmatrix}"),
-        ("np.ndarray([1, 2])", r"\begin{bmatrix} 1 & 2 \end{bmatrix}"),
+        ("array(1)", r"\mathrm{array}\mathopen{}\left({1}\mathclose{}\right)"),
         (
-            "np.ndarray([[1, 2], [3, 4]])",
-            r"\begin{bmatrix} 1 & 2 \\" r"3 & 4 \end{bmatrix}",
+            "array([])",
+            r"\mathrm{array}\mathopen{}\left(\left[ \right] \mathclose{}\right)",
+        ),
+        ("array([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
+        ("array([1, 2, 3])", r"\begin{bmatrix} {1} & {2} & {3} \end{bmatrix}"),
+        (
+            "array([[]])",
+            r"\mathrm{array}\mathopen{}\left("
+            r"\left[ \left[ \right] \right] "
+            r"\mathclose{}\right)",
+        ),
+        ("array([[1]])", r"\begin{bmatrix} {1} \end{bmatrix}"),
+        ("array([[1], [2], [3]])", r"\begin{bmatrix} {1} \\ {2} \\ {3} \end{bmatrix}"),
+        (
+            "array([[1], [2], [3, 4]])",
+            r"\mathrm{array}\mathopen{}\left("
+            r"\left[ "
+            r"\left[ {1}\right] \space,\space "
+            r"\left[ {2}\right] \space,\space "
+            r"\left[ {3}\space,\space {4}\right] "
+            r"\right] "
+            r"\mathclose{}\right)",
         ),
         (
-            "np.ndarray([[1,2], [3,4], [5,6]])",
-            r"\begin{bmatrix}"
-            r"1 & 2 \\" r"3 & 4 \\" r"5 & 6 " r"\end{bmatrix}"
+            "array([[1, 2], [3, 4], [5, 6]])",
+            r"\begin{bmatrix} {1} & {2} \\ {3} & {4} \\ {5} & {6} \end{bmatrix}",
         ),
-        ("np.ndarray([[1], [2], [3]])", r"\begin{bmatrix} 1 \\ 2 \\ 3 \end{bmatrix}"),
+        # Only checks two cases for ndarray.
+        ("ndarray(1)", r"\mathrm{ndarray}\mathopen{}\left({1}\mathclose{}\right)"),
+        ("ndarray([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
     ],
 )
 def test_numpy_array(code: str, latex: str) -> None:


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Supports following syntax (for example):

<img width="529" src="https://user-images.githubusercontent.com/1023695/205439433-16cb6eac-f189-4e25-973b-922ebaacbd06.png">


# Details

- Adds special treatment for `array` and `ndarray` functions to generate matrix expression.

# References

- Taken over from #118, thanks for initial implementation!
- Fixes #78 

# Blocked by

- NA
