### PR TITLE
Several refactoring and bugfix.

### DIFF
--- a/src/integration_tests/function_expansion_test.py
+++ b/src/integration_tests/function_expansion_test.py
@@ -3,23 +3,29 @@ import math
 from integration_tests import utils
 
 
-def test_expand_atan2_function() -> None:
+def test_atan2() -> None:
     def solve(x, y):
         return math.atan2(y, x)
 
-    latex = r"\mathrm{solve}(x, y) = \arctan{\left({\frac{y}{x}}\right)}"
+    latex = (
+        r"\mathrm{solve}(x, y) ="
+        r" \arctan \mathopen{}\left( \frac{y}{x} \mathclose{}\right)"
+    )
     utils.check_function(solve, latex, expand_functions={"atan2"})
 
 
-def test_expand_atan2_nested_function() -> None:
+def test_atan2_nested() -> None:
     def solve(x, y):
         return math.atan2(math.exp(y), math.exp(x))
 
-    latex = r"\mathrm{solve}(x, y) = \arctan{\left({\frac{e^{y}}{e^{x}}}\right)}"
+    latex = (
+        r"\mathrm{solve}(x, y) ="
+        r" \arctan \mathopen{}\left( \frac{e^{y}}{e^{x}} \mathclose{}\right)"
+    )
     utils.check_function(solve, latex, expand_functions={"atan2", "exp"})
 
 
-def test_expand_exp_function() -> None:
+def test_exp() -> None:
     def solve(x):
         return math.exp(x)
 
@@ -27,7 +33,7 @@ def test_expand_exp_function() -> None:
     utils.check_function(solve, latex, expand_functions={"exp"})
 
 
-def test_expand_exp_nested_function() -> None:
+def test_exp_nested() -> None:
     def solve(x):
         return math.exp(math.exp(x))
 
@@ -35,7 +41,7 @@ def test_expand_exp_nested_function() -> None:
     utils.check_function(solve, latex, expand_functions={"exp"})
 
 
-def test_expand_exp2_function() -> None:
+def test_exp2() -> None:
     def solve(x):
         return math.exp2(x)
 
@@ -43,7 +49,7 @@ def test_expand_exp2_function() -> None:
     utils.check_function(solve, latex, expand_functions={"exp2"})
 
 
-def test_expand_exp2_nested_function() -> None:
+def test_exp2_nested() -> None:
     def solve(x):
         return math.exp2(math.exp2(x))
 
@@ -51,15 +57,15 @@ def test_expand_exp2_nested_function() -> None:
     utils.check_function(solve, latex, expand_functions={"exp2"})
 
 
-def test_expand_expm1_function() -> None:
+def test_expm1() -> None:
     def solve(x):
         return math.expm1(x)
 
-    latex = r"\mathrm{solve}(x) = \exp{\left({x}\right)} - {1}"
+    latex = r"\mathrm{solve}(x) = \exp x - {1}"
     utils.check_function(solve, latex, expand_functions={"expm1"})
 
 
-def test_expand_expm1_nested_function() -> None:
+def test_expm1_nested() -> None:
     def solve(x, y, z):
         return math.expm1(math.pow(y, z))
 
@@ -67,54 +73,54 @@ def test_expand_expm1_nested_function() -> None:
     utils.check_function(solve, latex, expand_functions={"expm1", "exp", "pow"})
 
 
-def test_expand_hypot_function_without_attribute_access() -> None:
+def test_hypot_without_attribute() -> None:
     from math import hypot
 
     def solve(x, y, z):
         return hypot(x, y, z)
 
-    latex = r"\mathrm{solve}(x, y, z) = \sqrt{x^{{2}} + y^{{2}} + z^{{2}}}"
+    latex = r"\mathrm{solve}(x, y, z) = \sqrt{ x^{{2}} + y^{{2}} + z^{{2}} }"
     utils.check_function(solve, latex, expand_functions={"hypot"})
 
 
-def test_expand_hypot_function() -> None:
+def test_hypot() -> None:
     def solve(x, y, z):
         return math.hypot(x, y, z)
 
-    latex = r"\mathrm{solve}(x, y, z) = \sqrt{x^{{2}} + y^{{2}} + z^{{2}}}"
+    latex = r"\mathrm{solve}(x, y, z) = \sqrt{ x^{{2}} + y^{{2}} + z^{{2}} }"
     utils.check_function(solve, latex, expand_functions={"hypot"})
 
 
-def test_expand_hypot_nested_function() -> None:
+def test_hypot_nested() -> None:
     def solve(a, b, x, y):
         return math.hypot(math.hypot(a, b), x, y)
 
     latex = (
-        r"\mathrm{solve}(a, b, x, y) = "
-        r"\sqrt{"
-        r"\sqrt{a^{{2}} + b^{{2}}}^{{2}} + "
-        r"x^{{2}} + y^{{2}}}"
+        r"\mathrm{solve}(a, b, x, y) ="
+        r" \sqrt{ \sqrt{ a^{{2}} + b^{{2}} }^{{2}} + x^{{2}} + y^{{2}} }"
     )
     utils.check_function(solve, latex, expand_functions={"hypot"})
 
 
-def test_expand_log1p_function() -> None:
+def test_log1p() -> None:
     def solve(x):
         return math.log1p(x)
 
-    latex = r"\mathrm{solve}(x) = \log{\left({{1} + x}\right)}"
+    latex = r"\mathrm{solve}(x) = \log \mathopen{}\left( {1} + x \mathclose{}\right)"
     utils.check_function(solve, latex, expand_functions={"log1p"})
 
 
-def test_expand_log1p_nested_function() -> None:
+def test_log1p_nested() -> None:
     def solve(x):
         return math.log1p(math.exp(x))
 
-    latex = r"\mathrm{solve}(x) = \log{\left({{1} + e^{x}}\right)}"
+    latex = (
+        r"\mathrm{solve}(x) = \log \mathopen{}\left( {1} + e^{x} \mathclose{}\right)"
+    )
     utils.check_function(solve, latex, expand_functions={"log1p", "exp"})
 
 
-def test_expand_pow_nested_function() -> None:
+def test_pow_nested() -> None:
     def solve(w, x, y, z):
         return math.pow(math.pow(w, x), math.pow(y, z))
 
@@ -125,7 +131,7 @@ def test_expand_pow_nested_function() -> None:
     utils.check_function(solve, latex, expand_functions={"pow"})
 
 
-def test_expand_pow_function() -> None:
+def test_pow() -> None:
     def solve(x, y):
         return math.pow(x, y)
 

--- a/src/integration_tests/regression_test.py
+++ b/src/integration_tests/regression_test.py
@@ -11,7 +11,7 @@ def test_quadratic_solution() -> None:
     def solve(a, b, c):
         return (-b + math.sqrt(b**2 - 4 * a * c)) / (2 * a)
 
-    latex = r"\mathrm{solve}(a, b, c) = \frac{-b + \sqrt{b^{{2}} - {4} a c}}{{2} a}"
+    latex = r"\mathrm{solve}(a, b, c) = \frac{-b + \sqrt{ b^{{2}} - {4} a c }}{{2} a}"
     utils.check_function(solve, latex)
 
 
@@ -26,7 +26,7 @@ def test_sinc() -> None:
         r"\mathrm{sinc}(x) = "
         r"\left\{ \begin{array}{ll} "
         r"{1}, & \mathrm{if} \ "
-        r"{x = {0}} \\ \frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} "
+        r"{x = {0}} \\ \frac{\sin x}{x}, & \mathrm{otherwise} "
         r"\end{array} \right."
     )
     utils.check_function(sinc, latex)
@@ -201,9 +201,9 @@ def test_reduce_assignments_with_if() -> None:
         sigmoid,
         (
             r"\mathrm{sigmoid}(x) = \left\{ \begin{array}{ll} "
-            r"\frac{{1}}{{1} + \exp{\left({-x}\right)}}, & "
+            r"\frac{{1}}{{1} + \exp \mathopen{}\left( -x \mathclose{}\right)}, & "
             r"\mathrm{if} \ {x > {0}} \\ "
-            r"\frac{\exp{\left({x}\right)}}{\exp{\left({x}\right)} + {1}}, & "
+            r"\frac{\exp x}{\exp x + {1}}, & "
             r"\mathrm{otherwise} "
             r"\end{array} \right."
         ),

--- a/src/latexify/analyzers_test.py
+++ b/src/latexify/analyzers_test.py
@@ -6,7 +6,7 @@ import ast
 
 import pytest
 
-from latexify import analyzers, exceptions, test_utils
+from latexify import analyzers, ast_utils, exceptions, test_utils
 
 
 @test_utils.require_at_least(8)
@@ -105,7 +105,7 @@ def test_analyze_range(
     stop_int: int | None,
     step_int: int | None,
 ) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.Call)
 
     info = analyzers.analyze_range(node)
@@ -143,7 +143,7 @@ def test_analyze_range(
     ],
 )
 def test_analyze_range_invalid(code: str) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.Call)
 
     with pytest.raises(

--- a/src/latexify/ast_utils.py
+++ b/src/latexify/ast_utils.py
@@ -31,7 +31,7 @@ def make_name(id: str) -> ast.Name:
     return ast.Name(id=id, ctx=ast.Load())
 
 
-def make_attribute(value: ast.Expr, attr: str):
+def make_attribute(value: ast.expr, attr: str):
     """Generates a new Attribute node.
 
     Args:

--- a/src/latexify/ast_utils.py
+++ b/src/latexify/ast_utils.py
@@ -7,6 +7,18 @@ import sys
 from typing import Any
 
 
+def parse_expr(code: str) -> ast.expr:
+    """Parses given Python expression.
+
+    Args:
+        code: Python expression to parse.
+
+    Returns:
+        ast.expr corresponding to `code`.
+    """
+    return ast.parse(code, mode="eval").body
+
+
 def make_name(id: str) -> ast.Name:
     """Generates a new Name node.
 

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -10,6 +10,17 @@ import pytest
 from latexify import ast_utils, test_utils
 
 
+def test_parse_expr() -> None:
+    test_utils.assert_ast_equal(
+        ast_utils.parse_expr("a + b"),
+        ast.BinOp(
+            left=ast_utils.make_name("a"),
+            op=ast.Add(),
+            right=ast_utils.make_name("b"),
+        ),
+    )
+
+
 def test_make_name() -> None:
     test_utils.assert_ast_equal(
         ast_utils.make_name("foo"), ast.Name(id="foo", ctx=ast.Load())

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -369,7 +369,7 @@ class FunctionCodegen(ast.NodeVisitor):
         def generate_matrix_from_array(data: list[list[str]]) -> str:
             """Helper to generate a bmatrix environment."""
             contents = r" \\ ".join(" & ".join(row) for row in data)
-            return r"\begin{bmatrix} " + contents + r"\end{bmatrix}"
+            return r"\begin{bmatrix} " + contents + r" \end{bmatrix}"
 
         arg = node.args[0]
         if not isinstance(arg, ast.List) or not arg.elts:
@@ -380,7 +380,7 @@ class FunctionCodegen(ast.NodeVisitor):
 
         if not isinstance(row0, ast.List):
             # Maybe 1 x N array
-            return generate_matrix_from_array([self.visit(x) for x in arg.elts])
+            return generate_matrix_from_array([[self.visit(x) for x in arg.elts]])
 
         if not row0.elts:
             # No columns

--- a/src/latexify/codegen/function_codegen.py
+++ b/src/latexify/codegen/function_codegen.py
@@ -334,18 +334,84 @@ class FunctionCodegen(ast.NodeVisitor):
         wrapped = [r"\mathopen{}\left( " + s + r" \mathclose{}\right)" for s in conds]
         return r" \land ".join(wrapped)
 
+    def _generate_sum_prod(self, node: ast.Call) -> str | None:
+        """Generates sum/prod expression.
+
+        Args:
+            node: ast.Call node containing the sum/prod invocation.
+
+        Returns:
+            Generated LaTeX, or None if the node has unsupported syntax.
+        """
+        if not isinstance(node.args[0], ast.GeneratorExp):
+            return None
+
+        name = ast_utils.extract_function_name_or_none(node)
+        assert name is not None
+
+        elt, scripts = self._get_sum_prod_info(node.args[0])
+        scripts_str = [rf"\{name}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
+        return (
+            " ".join(scripts_str)
+            + rf" \mathopen{{}}\left({{{elt}}}\mathclose{{}}\right)"
+        )
+
+    def _generate_matrix(self, node: ast.Call) -> str | None:
+        """Generates matrix expression.
+
+        Args:
+            node: ast.Call node containing the ndarray invocation.
+
+        Returns:
+            Generated LaTeX, or None if the node has unsupported syntax.
+        """
+
+        def generate_matrix_from_array(data: list[list[str]]) -> str:
+            """Helper to generate a bmatrix environment."""
+            contents = r" \\ ".join(" & ".join(row) for row in data)
+            return r"\begin{bmatrix} " + contents + r"\end{bmatrix}"
+
+        arg = node.args[0]
+        if not isinstance(arg, ast.List) or not arg.elts:
+            # Not an array or no rows
+            return None
+
+        row0 = arg.elts[0]
+
+        if not isinstance(row0, ast.List):
+            # Maybe 1 x N array
+            return generate_matrix_from_array([self.visit(x) for x in arg.elts])
+
+        if not row0.elts:
+            # No columns
+            return None
+
+        ncols = len(row0.elts)
+
+        if not all(
+            isinstance(row, ast.List) and len(row.elts) == ncols for row in arg.elts
+        ):
+            # Length mismatch
+            return None
+
+        return generate_matrix_from_array(
+            [[self.visit(x) for x in row.elts] for row in arg.elts]
+        )
+
     def visit_Call(self, node: ast.Call) -> str:
         """Visit a call node."""
         func_name = ast_utils.extract_function_name_or_none(node)
 
-        # Special processing for sum and prod.
-        if func_name in ("sum", "prod") and isinstance(node.args[0], ast.GeneratorExp):
-            elt, scripts = self._get_sum_prod_info(node.args[0])
-            scripts_str = [rf"\{func_name}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
-            return (
-                " ".join(scripts_str)
-                + rf" \mathopen{{}}\left({{{elt}}}\mathclose{{}}\right)"
-            )
+        # Special treatments for some functions.
+        if func_name in ("sum", "prod"):
+            special_latex = self._generate_sum_prod(node)
+        elif func_name in ("array", "ndarray"):
+            special_latex = self._generate_matrix(node)
+        else:
+            special_latex = None
+
+        if special_latex is not None:
+            return special_latex
 
         # Function signature (possibly an expression).
         default_func_str = self.visit(node.func)
@@ -356,52 +422,8 @@ class FunctionCodegen(ast.NodeVisitor):
             (default_func_str + r"\mathopen{}\left(", r"\mathclose{}\right)"),
         )
 
-<<<<<<< HEAD
-=======
-        if func_str in ("ndarray", "array"):
-            arg = node.args[0]
-            if not isinstance(arg, ast.List) or not arg.elts:
-                return None
-
-            row0 = arg.elts[0]
-
-            if not isinstance(row0, ast.List):
-                return self._generate_ndarray([self.visit(x) for x in arg.elts])
-
-            if not row0.elts:
-                return None
-
-            nCols = len(row0.elts)
-
-            if not all(
-                isinstance(row, ast.List) and len(row.elts) == nCols for row in arg.elts
-            ):
-                return None
-
-            return self._generate_ndarray(
-                [[self.visit(x) for x in row.elts] for row in arg.elts]
-            )
-
-        if func_str in ("sum", "prod") and isinstance(node.args[0], ast.GeneratorExp):
-            elt, scripts = self._get_sum_prod_info(node.args[0])
-            scripts_str = [rf"\{func_str}_{{{lo}}}^{{{up}}}" for lo, up in scripts]
-            return " ".join(scripts_str) + rf" \left({{{elt}}}\right)"
-
->>>>>>> aaa/np-ndarray
         arg_strs = [self.visit(arg) for arg in node.args]
         return lstr + ", ".join(arg_strs) + rstr
-
-    def _generate_ndarray(self, data: list[list[str]]) -> str:
-        """Generates a latex matrix from a 2d list of strings.
-
-        Args:
-            data: A 2d list of strings.
-
-        Returns:
-            Generated LaTeX expression.
-        """
-        contents = r" \\ ".join(" & ".join(row) for row in data)
-        return r"\begin{bmatrix} " + contents + r" \end{bmatrix}"
 
     def visit_Attribute(self, node: ast.Attribute) -> str:
         vstr = self.visit(node.value)

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -7,7 +7,7 @@ import textwrap
 
 import pytest
 
-from latexify import exceptions, test_utils
+from latexify import ast_utils, exceptions, test_utils
 from latexify.codegen import FunctionCodegen, function_codegen
 
 
@@ -116,7 +116,7 @@ def test_visit_functiondef_ignore_multiple_constants() -> None:
     ],
 )
 def test_visit_listcomp(code: str, latex: str) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.ListComp)
     assert FunctionCodegen().visit(node) == latex
 
@@ -163,7 +163,7 @@ def test_visit_listcomp(code: str, latex: str) -> None:
     ],
 )
 def test_visit_setcomp(code: str, latex: str) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.SetComp)
     assert FunctionCodegen().visit(node) == latex
 
@@ -222,7 +222,7 @@ def test_visit_setcomp(code: str, latex: str) -> None:
 )
 def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
     for src_fn, dest_fn in [("sum", r"\sum"), ("prod", r"\prod")]:
-        node = ast.parse(src_fn + src_suffix).body[0].value
+        node = ast_utils.parse_expr(src_fn + src_suffix)
         assert isinstance(node, ast.Call)
         assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
 
@@ -273,7 +273,7 @@ def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
     ],
 )
 def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.Call)
     assert FunctionCodegen().visit(node) == latex
 
@@ -299,7 +299,7 @@ def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> No
 )
 def test_visit_call_sum_prod_with_if(src_suffix: str, dest_suffix: str) -> None:
     for src_fn, dest_fn in [("sum", r"\sum"), ("prod", r"\prod")]:
-        node = ast.parse(src_fn + src_suffix).body[0].value
+        node = ast_utils.parse_expr(src_fn + src_suffix)
         assert isinstance(node, ast.Call)
         assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
 
@@ -331,7 +331,7 @@ def test_visit_call_sum_prod_with_if(src_suffix: str, dest_suffix: str) -> None:
     ],
 )
 def test_if_then_else(code: str, latex: str) -> None:
-    node = ast.parse(code).body[0].value
+    node = ast_utils.parse_expr(code)
     assert isinstance(node, ast.IfExp)
     assert FunctionCodegen().visit(node) == latex
 
@@ -507,7 +507,7 @@ def test_if_then_else(code: str, latex: str) -> None:
     ],
 )
 def test_visit_binop(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.BinOp)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -546,7 +546,7 @@ def test_visit_binop(code: str, latex: str) -> None:
     ],
 )
 def test_visit_unaryop(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.UnaryOp)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -600,7 +600,7 @@ def test_visit_unaryop(code: str, latex: str) -> None:
     ],
 )
 def test_visit_compare(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Compare)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -646,7 +646,7 @@ def test_visit_compare(code: str, latex: str) -> None:
     ],
 )
 def test_visit_boolop(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.BoolOp)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -671,7 +671,7 @@ def test_visit_boolop(code: str, latex: str) -> None:
     ],
 )
 def test_visit_constant_lagacy(code: str, cls: type[ast.expr], latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, cls)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -696,7 +696,7 @@ def test_visit_constant_lagacy(code: str, cls: type[ast.expr], latex: str) -> No
     ],
 )
 def test_visit_constant(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Constant)
 
 
@@ -711,7 +711,7 @@ def test_visit_constant(code: str, latex: str) -> None:
     ],
 )
 def test_visit_subscript(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Subscript)
     assert function_codegen.FunctionCodegen().visit(tree) == latex
 
@@ -726,7 +726,7 @@ def test_visit_subscript(code: str, latex: str) -> None:
     ],
 )
 def test_use_set_symbols_binop(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.BinOp)
     assert function_codegen.FunctionCodegen(use_set_symbols=True).visit(tree) == latex
 
@@ -741,7 +741,7 @@ def test_use_set_symbols_binop(code: str, latex: str) -> None:
     ],
 )
 def test_use_set_symbols_compare(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Compare)
     assert function_codegen.FunctionCodegen(use_set_symbols=True).visit(tree) == latex
 
@@ -784,6 +784,6 @@ def test_use_set_symbols_compare(code: str, latex: str) -> None:
     ],
 )
 def test_numpy_array(code: str, latex: str) -> None:
-    tree = ast.parse(code).body[0].value
+    tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert function_codegen.FunctionCodegen().visit(tree) == latex

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -77,41 +77,90 @@ def test_visit_functiondef_ignore_multiple_constants() -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("[i for i in n]", r"\left[ i \mid i \in n \right]"),
+        ("()", r"\mathopen{}\left(  \mathclose{}\right)"),
+        ("(x,)", r"\mathopen{}\left( x \mathclose{}\right)"),
+        ("(x, y)", r"\mathopen{}\left( x, y \mathclose{}\right)"),
+        ("(x, y, z)", r"\mathopen{}\left( x, y, z \mathclose{}\right)"),
+    ],
+)
+def test_tuple(code: str, latex: str) -> None:
+    node = ast_utils.parse_expr(code)
+    assert isinstance(node, ast.Tuple)
+    assert FunctionCodegen().visit(node) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("[]", r"\mathopen{}\left[  \mathclose{}\right]"),
+        ("[x]", r"\mathopen{}\left[ x \mathclose{}\right]"),
+        ("[x, y]", r"\mathopen{}\left[ x, y \mathclose{}\right]"),
+        ("[x, y, z]", r"\mathopen{}\left[ x, y, z \mathclose{}\right]"),
+    ],
+)
+def test_list(code: str, latex: str) -> None:
+    node = ast_utils.parse_expr(code)
+    assert isinstance(node, ast.List)
+    assert FunctionCodegen().visit(node) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        # TODO(odashi): Support set().
+        # ("set()", r"\mathopen{}\left\{  \mathclose{}\right\}"),
+        ("{x}", r"\mathopen{}\left\{ x \mathclose{}\right\}"),
+        ("{x, y}", r"\mathopen{}\left\{ x, y \mathclose{}\right\}"),
+        ("{x, y, z}", r"\mathopen{}\left\{ x, y, z \mathclose{}\right\}"),
+    ],
+)
+def test_set(code: str, latex: str) -> None:
+    node = ast_utils.parse_expr(code)
+    assert isinstance(node, ast.Set)
+    assert FunctionCodegen().visit(node) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("[i for i in n]", r"\mathopen{}\left[ i \mid i \in n \mathclose{}\right]"),
         (
             "[i for i in n if i > 0]",
-            r"\left[ i \mid"
+            r"\mathopen{}\left[ i \mid"
             r" \mathopen{}\left( i \in n \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right]",
+            r" \mathclose{}\right]",
         ),
         (
             "[i for i in n if i > 0 if f(i)]",
-            r"\left[ i \mid"
+            r"\mathopen{}\left[ i \mid"
             r" \mathopen{}\left( i \in n \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \land \mathopen{}\left( f\mathopen{}\left("
-            r"i\mathclose{}\right) \mathclose{}\right)"
-            r" \right]",
+            r" \land \mathopen{}\left( f \mathopen{}\left("
+            r" i \mathclose{}\right) \mathclose{}\right)"
+            r" \mathclose{}\right]",
         ),
-        ("[i for k in n for i in k]", r"\left[ i \mid k \in n, i \in k" r" \right]"),
+        (
+            "[i for k in n for i in k]",
+            r"\mathopen{}\left[ i \mid k \in n, i \in k" r" \mathclose{}\right]",
+        ),
         (
             "[i for k in n for i in k if i > 0]",
-            r"\left[ i \mid"
+            r"\mathopen{}\left[ i \mid"
             r" k \in n,"
             r" \mathopen{}\left( i \in k \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right]",
+            r" \mathclose{}\right]",
         ),
         (
             "[i for k in n if f(k) for i in k if i > 0]",
-            r"\left[ i \mid"
+            r"\mathopen{}\left[ i \mid"
             r" \mathopen{}\left( k \in n \mathclose{}\right)"
-            r" \land \mathopen{}\left( f\mathopen{}\left("
-            r"k\mathclose{}\right) \mathclose{}\right),"
+            r" \land \mathopen{}\left( f \mathopen{}\left("
+            r" k \mathclose{}\right) \mathclose{}\right),"
             r" \mathopen{}\left( i \in k \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right]",
+            r" \mathclose{}\right]",
         ),
     ],
 )
@@ -124,41 +173,44 @@ def test_visit_listcomp(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("{i for i in n}", r"\left\{ i \mid i \in n \right\}"),
+        ("{i for i in n}", r"\mathopen{}\left\{ i \mid i \in n \mathclose{}\right\}"),
         (
             "{i for i in n if i > 0}",
-            r"\left\{ i \mid"
+            r"\mathopen{}\left\{ i \mid"
             r" \mathopen{}\left( i \in n \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right\}",
+            r" \mathclose{}\right\}",
         ),
         (
             "{i for i in n if i > 0 if f(i)}",
-            r"\left\{ i \mid"
+            r"\mathopen{}\left\{ i \mid"
             r" \mathopen{}\left( i \in n \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \land \mathopen{}\left( f\mathopen{}\left("
-            r"i\mathclose{}\right) \mathclose{}\right)"
-            r" \right\}",
+            r" \land \mathopen{}\left( f \mathopen{}\left("
+            r" i \mathclose{}\right) \mathclose{}\right)"
+            r" \mathclose{}\right\}",
         ),
-        ("{i for k in n for i in k}", r"\left\{ i \mid k \in n, i \in k" r" \right\}"),
+        (
+            "{i for k in n for i in k}",
+            r"\mathopen{}\left\{ i \mid k \in n, i \in k" r" \mathclose{}\right\}",
+        ),
         (
             "{i for k in n for i in k if i > 0}",
-            r"\left\{ i \mid"
+            r"\mathopen{}\left\{ i \mid"
             r" k \in n,"
             r" \mathopen{}\left( i \in k \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right\}",
+            r" \mathclose{}\right\}",
         ),
         (
             "{i for k in n if f(k) for i in k if i > 0}",
-            r"\left\{ i \mid"
+            r"\mathopen{}\left\{ i \mid"
             r" \mathopen{}\left( k \in n \mathclose{}\right)"
-            r" \land \mathopen{}\left( f\mathopen{}\left("
-            r"k\mathclose{}\right) \mathclose{}\right),"
+            r" \land \mathopen{}\left( f \mathopen{}\left("
+            r" k \mathclose{}\right) \mathclose{}\right),"
             r" \mathopen{}\left( i \in k \mathclose{}\right)"
             r" \land \mathopen{}\left( {i > {0}} \mathclose{}\right)"
-            r" \right\}",
+            r" \mathclose{}\right\}",
         ),
     ],
 )
@@ -169,29 +221,86 @@ def test_visit_setcomp(code: str, latex: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("foo(x)", r"\mathrm{foo} \mathopen{}\left( x \mathclose{}\right)"),
+        ("f(x)", r"f \mathopen{}\left( x \mathclose{}\right)"),
+        ("f(-x)", r"f \mathopen{}\left( -x \mathclose{}\right)"),
+        ("f(x + y)", r"f \mathopen{}\left( x + y \mathclose{}\right)"),
+        (
+            "f(f(x))",
+            r"f \mathopen{}\left("
+            r" f \mathopen{}\left( x \mathclose{}\right)"
+            r" \mathclose{}\right)",
+        ),
+        ("f(sqrt(x))", r"f \mathopen{}\left( \sqrt{ x } \mathclose{}\right)"),
+        ("f(sin(x))", r"f \mathopen{}\left( \sin x \mathclose{}\right)"),
+        ("f(factorial(x))", r"f \mathopen{}\left( x ! \mathclose{}\right)"),
+        ("f(x, y)", r"f \mathopen{}\left( x, y \mathclose{}\right)"),
+        ("sqrt(x)", r"\sqrt{ x }"),
+        ("sqrt(-x)", r"\sqrt{ -x }"),
+        ("sqrt(x + y)", r"\sqrt{ x + y }"),
+        ("sqrt(f(x))", r"\sqrt{ f \mathopen{}\left( x \mathclose{}\right) }"),
+        ("sqrt(sqrt(x))", r"\sqrt{ \sqrt{ x } }"),
+        ("sqrt(sin(x))", r"\sqrt{ \sin x }"),
+        ("sqrt(factorial(x))", r"\sqrt{ x ! }"),
+        ("sin(x)", r"\sin x"),
+        ("sin(-x)", r"\sin \mathopen{}\left( -x \mathclose{}\right)"),
+        ("sin(x + y)", r"\sin \mathopen{}\left( x + y \mathclose{}\right)"),
+        ("sin(f(x))", r"\sin f \mathopen{}\left( x \mathclose{}\right)"),
+        ("sin(sqrt(x))", r"\sin \sqrt{ x }"),
+        ("sin(sin(x))", r"\sin \sin x"),
+        ("sin(factorial(x))", r"\sin \mathopen{}\left( x ! \mathclose{}\right)"),
+        ("factorial(x)", r"x !"),
+        ("factorial(-x)", r"\mathopen{}\left( -x \mathclose{}\right) !"),
+        ("factorial(x + y)", r"\mathopen{}\left( x + y \mathclose{}\right) !"),
+        (
+            "factorial(f(x))",
+            r"\mathopen{}\left("
+            r" f \mathopen{}\left( x \mathclose{}\right)"
+            r" \mathclose{}\right) !",
+        ),
+        ("factorial(sqrt(x))", r"\mathopen{}\left( \sqrt{ x } \mathclose{}\right) !"),
+        ("factorial(sin(x))", r"\mathopen{}\left( \sin x \mathclose{}\right) !"),
+        ("factorial(factorial(x))", r"\mathopen{}\left( x ! \mathclose{}\right) !"),
+    ],
+)
+def test_visit_call(code: str, latex: str) -> None:
+    node = ast_utils.parse_expr(code)
+    assert isinstance(node, ast.Call)
+    assert FunctionCodegen().visit(node) == latex
+
+
+@pytest.mark.parametrize(
     "src_suffix,dest_suffix",
     [
         # No comprehension
-        ("(x)", r" \left({x}\right)"),
-        ("([1, 2])", r" \left({\left[ {1}\space,\space {2}\right] }\right)"),
-        ("({1, 2})", r" \left({\left\{ {1}\space,\space {2}\right\} }\right)"),
-        ("(f(x))", r" \left({f\mathopen{}\left(x\mathclose{}\right)}\right)"),
+        ("(x)", r" x"),
+        (
+            "([1, 2])",
+            r" \mathopen{}\left[ {1}, {2} \mathclose{}\right]",
+        ),
+        (
+            "({1, 2})",
+            r" \mathopen{}\left\{ {1}, {2} \mathclose{}\right\}",
+        ),
+        ("(f(x))", r" f \mathopen{}\left( x \mathclose{}\right)"),
         # Single comprehension
         ("(i for i in x)", r"_{i \in x}^{} \mathopen{}\left({i}\mathclose{}\right)"),
         (
             "(i for i in [1, 2])",
-            r"_{i \in \left[ {1}\space,\space {2}\right] }^{} "
+            r"_{i \in \mathopen{}\left[ {1}, {2} \mathclose{}\right]}^{} "
             r"\mathopen{}\left({i}\mathclose{}\right)",
         ),
         (
             "(i for i in {1, 2})",
-            r"_{i \in \left\{ {1}\space,\space {2}\right\} }^{} "
-            r"\mathopen{}\left({i}\mathclose{}\right)",
+            r"_{i \in \mathopen{}\left\{ {1}, {2} \mathclose{}\right\}}^{}"
+            r" \mathopen{}\left({i}\mathclose{}\right)",
         ),
         (
             "(i for i in f(x))",
-            r"_{i \in f\mathopen{}\left(x\mathclose{}\right)}^{} "
-            r"\mathopen{}\left({i}\mathclose{}\right)",
+            r"_{i \in f \mathopen{}\left( x \mathclose{}\right)}^{}"
+            r" \mathopen{}\left({i}\mathclose{}\right)",
         ),
         (
             "(i for i in range(n))",
@@ -215,13 +324,13 @@ def test_visit_setcomp(code: str, latex: str) -> None:
         ),
         (
             "(i for i in range(n, m, k))",
-            r"_{i \in \mathrm{range}\mathopen{}\left(n, m, k"
-            r"\mathclose{}\right)}^{} \mathopen{}\left({i}\mathclose{}\right)",
+            r"_{i \in \mathrm{range} \mathopen{}\left( n, m, k \mathclose{}\right)}^{}"
+            r" \mathopen{}\left({i}\mathclose{}\right)",
         ),
     ],
 )
 def test_visit_call_sum_prod(src_suffix: str, dest_suffix: str) -> None:
-    for src_fn, dest_fn in [("sum", r"\sum"), ("prod", r"\prod")]:
+    for src_fn, dest_fn in [("fsum", r"\sum"), ("sum", r"\sum"), ("prod", r"\prod")]:
         node = ast_utils.parse_expr(src_fn + src_suffix)
         assert isinstance(node, ast.Call)
         assert FunctionCodegen().visit(node) == dest_fn + dest_suffix
@@ -289,10 +398,10 @@ def test_visit_call_sum_prod_multiple_comprehension(code: str, latex: str) -> No
         ),
         (
             "(i for i in x if i < y if f(i))",
-            r"_{\mathopen{}\left( i \in x \mathclose{}\right) "
-            r"\land \mathopen{}\left( {i < y} \mathclose{}\right)"
-            r" \land \mathopen{}\left( f\mathopen{}\left("
-            r"i\mathclose{}\right) \mathclose{}\right)}^{}"
+            r"_{\mathopen{}\left( i \in x \mathclose{}\right)"
+            r" \land \mathopen{}\left( {i < y} \mathclose{}\right)"
+            r" \land \mathopen{}\left( f \mathopen{}\left("
+            r" i \mathclose{}\right) \mathclose{}\right)}^{}"
             r" \mathopen{}\left({i}\mathclose{}\right)",
         ),
     ],
@@ -469,14 +578,21 @@ def test_if_then_else(code: str, latex: str) -> None:
         # is_wrapped
         ("(x // y)**z", r"\left\lfloor\frac{x}{y}\right\rfloor^{z}"),
         # With Call
-        ("x**f(y)", r"x^{f\mathopen{}\left(y\mathclose{}\right)}"),
-        ("f(x)**y", r"f\mathopen{}\left(x\mathclose{}\right)^{y}"),
-        ("x * f(y)", r"x f\mathopen{}\left(y\mathclose{}\right)"),
-        ("f(x) * y", r"f\mathopen{}\left(x\mathclose{}\right) y"),
-        ("x / f(y)", r"\frac{x}{f\mathopen{}\left(y\mathclose{}\right)}"),
-        ("f(x) / y", r"\frac{f\mathopen{}\left(x\mathclose{}\right)}{y}"),
-        ("x + f(y)", r"x + f\mathopen{}\left(y\mathclose{}\right)"),
-        ("f(x) + y", r"f\mathopen{}\left(x\mathclose{}\right) + y"),
+        ("x**f(y)", r"x^{f \mathopen{}\left( y \mathclose{}\right)}"),
+        (
+            "f(x)**y",
+            r"\mathopen{}\left("
+            r" f \mathopen{}\left( x \mathclose{}\right)"
+            r" \mathclose{}\right)^{y}",
+        ),
+        ("x * f(y)", r"x f \mathopen{}\left( y \mathclose{}\right)"),
+        ("f(x) * y", r"f \mathopen{}\left( x \mathclose{}\right) y"),
+        ("x / f(y)", r"\frac{x}{f \mathopen{}\left( y \mathclose{}\right)}"),
+        ("f(x) / y", r"\frac{f \mathopen{}\left( x \mathclose{}\right)}{y}"),
+        ("x + f(y)", r"x + f \mathopen{}\left( y \mathclose{}\right)"),
+        ("f(x) + y", r"f \mathopen{}\left( x \mathclose{}\right) + y"),
+        # With is_wrapped Call
+        ("sqrt(x) ** y", r"\sqrt{ x }^{y}"),
         # With UnaryOp
         ("x**-y", r"x^{-y}"),
         ("(-x)**y", r"\mathopen{}\left( -x \mathclose{}\right)^{y}"),
@@ -521,10 +637,10 @@ def test_visit_binop(code: str, latex: str) -> None:
         ("~x", r"\mathord{\sim} x"),
         ("not x", r"\lnot x"),
         # With Call
-        ("+f(x)", r"+f\mathopen{}\left(x\mathclose{}\right)"),
-        ("-f(x)", r"-f\mathopen{}\left(x\mathclose{}\right)"),
-        ("~f(x)", r"\mathord{\sim} f\mathopen{}\left(x\mathclose{}\right)"),
-        ("not f(x)", r"\lnot f\mathopen{}\left(x\mathclose{}\right)"),
+        ("+f(x)", r"+f \mathopen{}\left( x \mathclose{}\right)"),
+        ("-f(x)", r"-f \mathopen{}\left( x \mathclose{}\right)"),
+        ("~f(x)", r"\mathord{\sim} f \mathopen{}\left( x \mathclose{}\right)"),
+        ("not f(x)", r"\lnot f \mathopen{}\left( x \mathclose{}\right)"),
         # With BinOp
         ("+(x + y)", r"+\mathopen{}\left( x + y \mathclose{}\right)"),
         ("-(x + y)", r"-\mathopen{}\left( x + y \mathclose{}\right)"),
@@ -584,8 +700,8 @@ def test_visit_unaryop(code: str, latex: str) -> None:
         ("a <= b < c", r"{a \le b < c}"),
         ("a <= b <= c", r"{a \le b \le c}"),
         # With Call
-        ("a == f(b)", r"{a = f\mathopen{}\left(b\mathclose{}\right)}"),
-        ("f(a) == b", r"{f\mathopen{}\left(a\mathclose{}\right) = b}"),
+        ("a == f(b)", r"{a = f \mathopen{}\left( b \mathclose{}\right)}"),
+        ("f(a) == b", r"{f \mathopen{}\left( a \mathclose{}\right) = b}"),
         # With BinOp
         ("a == b + c", r"{a = b + c}"),
         ("a + b == c", r"{a + b = c}"),
@@ -624,10 +740,10 @@ def test_visit_compare(code: str, latex: str) -> None:
             r"{a \land \mathopen{}\left( {b \lor c} \mathclose{}\right)}",
         ),
         # With Call
-        ("a and f(b)", r"{a \land f\mathopen{}\left(b\mathclose{}\right)}"),
-        ("f(a) and b", r"{f\mathopen{}\left(a\mathclose{}\right) \land b}"),
-        ("a or f(b)", r"{a \lor f\mathopen{}\left(b\mathclose{}\right)}"),
-        ("f(a) or b", r"{f\mathopen{}\left(a\mathclose{}\right) \lor b}"),
+        ("a and f(b)", r"{a \land f \mathopen{}\left( b \mathclose{}\right)}"),
+        ("f(a) and b", r"{f \mathopen{}\left( a \mathclose{}\right) \land b}"),
+        ("a or f(b)", r"{a \lor f \mathopen{}\left( b \mathclose{}\right)}"),
+        ("f(a) or b", r"{f \mathopen{}\left( a \mathclose{}\right) \lor b}"),
         # With BinOp
         ("a and b + c", r"{a \land b + c}"),
         ("a + b and c", r"{a + b \land c}"),
@@ -707,7 +823,7 @@ def test_visit_constant(code: str, latex: str) -> None:
         ("x[0][1]", "{x_{{0}, {1}}}"),
         ("x[0][1][2]", "{x_{{0}, {1}, {2}}}"),
         ("x[foo]", r"{x_{\mathrm{foo}}}"),
-        ("x[floor(x)]", r"{x_{\left\lfloor{x}\right\rfloor}}"),
+        ("x[floor(x)]", r"{x_{\mathopen{}\left\lfloor x \mathclose{}\right\rfloor}}"),
     ],
 )
 def test_visit_subscript(code: str, latex: str) -> None:
@@ -749,37 +865,40 @@ def test_use_set_symbols_compare(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("array(1)", r"\mathrm{array}\mathopen{}\left({1}\mathclose{}\right)"),
+        ("array(1)", r"\mathrm{array} \mathopen{}\left( {1} \mathclose{}\right)"),
         (
             "array([])",
-            r"\mathrm{array}\mathopen{}\left(\left[ \right] \mathclose{}\right)",
+            r"\mathrm{array} \mathopen{}\left("
+            r" \mathopen{}\left[  \mathclose{}\right]"
+            r" \mathclose{}\right)",
         ),
         ("array([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
         ("array([1, 2, 3])", r"\begin{bmatrix} {1} & {2} & {3} \end{bmatrix}"),
         (
             "array([[]])",
-            r"\mathrm{array}\mathopen{}\left("
-            r"\left[ \left[ \right] \right] "
-            r"\mathclose{}\right)",
+            r"\mathrm{array} \mathopen{}\left("
+            r" \mathopen{}\left[ \mathopen{}\left["
+            r"  \mathclose{}\right] \mathclose{}\right]"
+            r" \mathclose{}\right)",
         ),
         ("array([[1]])", r"\begin{bmatrix} {1} \end{bmatrix}"),
         ("array([[1], [2], [3]])", r"\begin{bmatrix} {1} \\ {2} \\ {3} \end{bmatrix}"),
         (
             "array([[1], [2], [3, 4]])",
-            r"\mathrm{array}\mathopen{}\left("
-            r"\left[ "
-            r"\left[ {1}\right] \space,\space "
-            r"\left[ {2}\right] \space,\space "
-            r"\left[ {3}\space,\space {4}\right] "
-            r"\right] "
-            r"\mathclose{}\right)",
+            r"\mathrm{array} \mathopen{}\left("
+            r" \mathopen{}\left["
+            r" \mathopen{}\left[ {1} \mathclose{}\right],"
+            r" \mathopen{}\left[ {2} \mathclose{}\right],"
+            r" \mathopen{}\left[ {3}, {4} \mathclose{}\right]"
+            r" \mathclose{}\right]"
+            r" \mathclose{}\right)",
         ),
         (
             "array([[1, 2], [3, 4], [5, 6]])",
             r"\begin{bmatrix} {1} & {2} \\ {3} & {4} \\ {5} & {6} \end{bmatrix}",
         ),
         # Only checks two cases for ndarray.
-        ("ndarray(1)", r"\mathrm{ndarray}\mathopen{}\left({1}\mathclose{}\right)"),
+        ("ndarray(1)", r"\mathrm{ndarray} \mathopen{}\left( {1} \mathclose{}\right)"),
         ("ndarray([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
     ],
 )

--- a/src/latexify/codegen/function_codegen_test.py
+++ b/src/latexify/codegen/function_codegen_test.py
@@ -749,18 +749,38 @@ def test_use_set_symbols_compare(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("np.ndarray([1])", r"\begin{bmatrix} 1 \end{bmatrix}"),
-        ("np.ndarray([1, 2])", r"\begin{bmatrix} 1 & 2 \end{bmatrix}"),
+        ("array(1)", r"\mathrm{array}\mathopen{}\left({1}\mathclose{}\right)"),
         (
-            "np.ndarray([[1, 2], [3, 4]])",
-            r"\begin{bmatrix} 1 & 2 \\" r"3 & 4 \end{bmatrix}",
+            "array([])",
+            r"\mathrm{array}\mathopen{}\left(\left[ \right] \mathclose{}\right)",
+        ),
+        ("array([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
+        ("array([1, 2, 3])", r"\begin{bmatrix} {1} & {2} & {3} \end{bmatrix}"),
+        (
+            "array([[]])",
+            r"\mathrm{array}\mathopen{}\left("
+            r"\left[ \left[ \right] \right] "
+            r"\mathclose{}\right)",
+        ),
+        ("array([[1]])", r"\begin{bmatrix} {1} \end{bmatrix}"),
+        ("array([[1], [2], [3]])", r"\begin{bmatrix} {1} \\ {2} \\ {3} \end{bmatrix}"),
+        (
+            "array([[1], [2], [3, 4]])",
+            r"\mathrm{array}\mathopen{}\left("
+            r"\left[ "
+            r"\left[ {1}\right] \space,\space "
+            r"\left[ {2}\right] \space,\space "
+            r"\left[ {3}\space,\space {4}\right] "
+            r"\right] "
+            r"\mathclose{}\right)",
         ),
         (
-            "np.ndarray([[1,2], [3,4], [5,6]])",
-            r"\begin{bmatrix}"
-            r"1 & 2 \\" r"3 & 4 \\" r"5 & 6 " r"\end{bmatrix}"
+            "array([[1, 2], [3, 4], [5, 6]])",
+            r"\begin{bmatrix} {1} & {2} \\ {3} & {4} \\ {5} & {6} \end{bmatrix}",
         ),
-        ("np.ndarray([[1], [2], [3]])", r"\begin{bmatrix} 1 \\ 2 \\ 3 \end{bmatrix}"),
+        # Only checks two cases for ndarray.
+        ("ndarray(1)", r"\mathrm{ndarray}\mathopen{}\left({1}\mathclose{}\right)"),
+        ("ndarray([1])", r"\begin{bmatrix} {1} \end{bmatrix}"),
     ],
 )
 def test_numpy_array(code: str, latex: str) -> None:

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import enum
 
 
@@ -42,37 +43,63 @@ class BuiltinFnName(str, enum.Enum):
     SUM = "sum"
 
 
-BUILTIN_FUNCS: dict[BuiltinFnName, tuple[str, str]] = {
-    BuiltinFnName.ABS: (r"\left|{", r"}\right|"),
-    BuiltinFnName.ACOS: (r"\arccos{\left({", r"}\right)}"),
-    BuiltinFnName.ACOSH: (r"\mathrm{arccosh}{\left({", r"}\right)}"),
-    BuiltinFnName.ARCCOS: (r"\arccos{\left({", r"}\right)}"),
-    BuiltinFnName.ARCCOSH: (r"\mathrm{arccosh}{\left({", r"}\right)}"),
-    BuiltinFnName.ARCSIN: (r"\arcsin{\left({", r"}\right)}"),
-    BuiltinFnName.ARCSINH: (r"\mathrm{arcsinh}{\left({", r"}\right)}"),
-    BuiltinFnName.ARCTAN: (r"\arctan{\left({", r"}\right)}"),
-    BuiltinFnName.ARCTANH: (r"\mathrm{arctanh}{\left({", r"}\right)}"),
-    BuiltinFnName.ASIN: (r"\arcsin{\left({", r"}\right)}"),
-    BuiltinFnName.ASINH: (r"\mathrm{arcsinh}{\left({", r"}\right)}"),
-    BuiltinFnName.ATAN: (r"\arctan{\left({", r"}\right)}"),
-    BuiltinFnName.ATANH: (r"\mathrm{arctanh}{\left({", r"}\right)}"),
-    BuiltinFnName.CEIL: (r"\left\lceil{", r"}\right\rceil"),
-    BuiltinFnName.COS: (r"\cos{\left({", r"}\right)}"),
-    BuiltinFnName.COSH: (r"\cosh{\left({", r"}\right)}"),
-    BuiltinFnName.EXP: (r"\exp{\left({", r"}\right)}"),
-    BuiltinFnName.FABS: (r"\left|{", r"}\right|"),
-    BuiltinFnName.FACTORIAL: (r"\left({", r"}\right)!"),
-    BuiltinFnName.FLOOR: (r"\left\lfloor{", r"}\right\rfloor"),
-    BuiltinFnName.FSUM: (r"\sum\left({", r"}\right)"),
-    BuiltinFnName.GAMMA: (r"\Gamma\left({", r"}\right)"),
-    BuiltinFnName.LOG: (r"\log{\left({", r"}\right)}"),
-    BuiltinFnName.LOG10: (r"\log_{10}{\left({", r"}\right)}"),
-    BuiltinFnName.LOG2: (r"\log_{2}{\left({", r"}\right)}"),
-    BuiltinFnName.PROD: (r"\prod \left({", r"}\right)"),
-    BuiltinFnName.SIN: (r"\sin{\left({", r"}\right)}"),
-    BuiltinFnName.SINH: (r"\sinh{\left({", r"}\right)}"),
-    BuiltinFnName.SQRT: (r"\sqrt{", "}"),
-    BuiltinFnName.TAN: (r"\tan{\left({", r"}\right)}"),
-    BuiltinFnName.TANH: (r"\tanh{\left({", r"}\right)}"),
-    BuiltinFnName.SUM: (r"\sum \left({", r"}\right)"),
+@dataclasses.dataclass(frozen=True)
+class FunctionRule:
+    """Codegen rules for functions.
+
+    Attributes:
+        left: LaTeX expression concatenated to the left-hand side of the arguments.
+        right: LaTeX expression concatenated to the right-hand side of the arguments.
+        is_unary: Whether the function is treated as a unary operator or not.
+        is_wrapped: Whether the resulting syntax is wrapped by brackets or not.
+    """
+
+    left: str
+    right: str = ""
+    is_unary: bool = False
+    is_wrapped: bool = False
+
+
+# name => left_syntax, right_syntax, is_wrapped
+BUILTIN_FUNCS: dict[BuiltinFnName, FunctionRule] = {
+    BuiltinFnName.ABS: FunctionRule(
+        r"\mathropen{}\left|", r"\mathclose{}\right|", is_wrapped=True
+    ),
+    BuiltinFnName.ACOS: FunctionRule(r"\arccos", is_unary=True),
+    BuiltinFnName.ACOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    BuiltinFnName.ARCCOS: FunctionRule(r"\arccos", is_unary=True),
+    BuiltinFnName.ARCCOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    BuiltinFnName.ARCSIN: FunctionRule(r"\arcsin", is_unary=True),
+    BuiltinFnName.ARCSINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    BuiltinFnName.ARCTAN: FunctionRule(r"\arctan", is_unary=True),
+    BuiltinFnName.ARCTANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    BuiltinFnName.ASIN: FunctionRule(r"\arcsin", is_unary=True),
+    BuiltinFnName.ASINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    BuiltinFnName.ATAN: FunctionRule(r"\arctan", is_unary=True),
+    BuiltinFnName.ATANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    BuiltinFnName.CEIL: FunctionRule(
+        r"\mathopen{}\left\lceil", r"\mathclose{}\right\rceil", is_wrapped=True
+    ),
+    BuiltinFnName.COS: FunctionRule(r"\cos", is_unary=True),
+    BuiltinFnName.COSH: FunctionRule(r"\cosh", is_unary=True),
+    BuiltinFnName.EXP: FunctionRule(r"\exp", is_unary=True),
+    BuiltinFnName.FABS: FunctionRule(
+        r"\mathopen{}\left|", r"\mathclose{}\right|", is_wrapped=True
+    ),
+    BuiltinFnName.FACTORIAL: FunctionRule("", "!", is_unary=True),
+    BuiltinFnName.FLOOR: FunctionRule(
+        r"\mathopen{}\left\lfloor", r"\mathclose{}\right\rfloor", is_wrapped=True
+    ),
+    BuiltinFnName.FSUM: FunctionRule(r"\sum", is_unary=True),
+    BuiltinFnName.GAMMA: FunctionRule(r"\Gamma"),
+    BuiltinFnName.LOG: FunctionRule(r"\log", is_unary=True),
+    BuiltinFnName.LOG10: FunctionRule(r"\log_{10}", is_unary=True),
+    BuiltinFnName.LOG2: FunctionRule(r"\log_{2}", is_unary=True),
+    BuiltinFnName.PROD: FunctionRule(r"\prod", is_unary=True),
+    BuiltinFnName.SIN: FunctionRule(r"\sin", is_unary=True),
+    BuiltinFnName.SINH: FunctionRule(r"\sinh", is_unary=True),
+    BuiltinFnName.SQRT: FunctionRule(r"\sqrt{", "}", is_wrapped=True),
+    BuiltinFnName.SUM: FunctionRule(r"\sum", is_unary=True),
+    BuiltinFnName.TAN: FunctionRule(r"\tan", is_unary=True),
+    BuiltinFnName.TANH: FunctionRule(r"\tanh", is_unary=True),
 }


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This change contains following changes:

- Fix a bug in `FunctionExpander`: the original implementation does not process nested functions if the outer function is retained.
- More accurate judgment to add parenthesis around functions. The new implementation tries to remove some parenthesis, e.g., $\sin (x)$ --> $\sin x$.
- Adjusts old codegen rules around tuple/list/set.
- Simplifying some tests, and providing more exhaustive tests.
- Some small refactoring.

# Details

New features added by this change is follows:

- `FunctionRule` dataclass, representing a codegen rule of a builtin function.
- Defines the default precedence of `ast.Call` as a value just above unary operators so that unary operators are wrapped by parenthesis:
  - `sin(x)` --> $\sin x$
  - `sin(-x)` --> $\sin (-x)$

# References

- NA

# Blocked by

- #144
