### PR TITLE
Revert BuiltinFnName

### DIFF
--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -6,43 +6,6 @@ import dataclasses
 import enum
 
 
-class BuiltinFnName(str, enum.Enum):
-    """Built-in function name."""
-
-    ABS = "abs"
-    ACOS = "acos"
-    ACOSH = "acosh"
-    ARCCOS = "arccos"
-    ARCCOSH = "arcosh"
-    ARCSIN = "arcsin"
-    ARCSINH = "arcsihn"
-    ARCTAN = "arctan"
-    ARCTANH = "arctanh"
-    ASIN = "asin"
-    ASINH = "asinh"
-    ATAN = "atan"
-    ATANH = "atanh"
-    CEIL = "ceil"
-    COS = "cos"
-    COSH = "cosh"
-    EXP = "exp"
-    FABS = "fabs"
-    FACTORIAL = "factorial"
-    FLOOR = "floor"
-    FSUM = "fsum"
-    GAMMA = "gamma"
-    LOG = "log"
-    LOG10 = "log10"
-    LOG2 = "log2"
-    PROD = "prod"
-    SIN = "sin"
-    SINH = "sinh"
-    SQRT = "sqrt"
-    TAN = "tan"
-    TANH = "tanh"
-    SUM = "sum"
-
-
 @dataclasses.dataclass(frozen=True)
 class FunctionRule:
     """Codegen rules for functions.
@@ -61,45 +24,41 @@ class FunctionRule:
 
 
 # name => left_syntax, right_syntax, is_wrapped
-BUILTIN_FUNCS: dict[BuiltinFnName, FunctionRule] = {
-    BuiltinFnName.ABS: FunctionRule(
-        r"\mathropen{}\left|", r"\mathclose{}\right|", is_wrapped=True
-    ),
-    BuiltinFnName.ACOS: FunctionRule(r"\arccos", is_unary=True),
-    BuiltinFnName.ACOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
-    BuiltinFnName.ARCCOS: FunctionRule(r"\arccos", is_unary=True),
-    BuiltinFnName.ARCCOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
-    BuiltinFnName.ARCSIN: FunctionRule(r"\arcsin", is_unary=True),
-    BuiltinFnName.ARCSINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
-    BuiltinFnName.ARCTAN: FunctionRule(r"\arctan", is_unary=True),
-    BuiltinFnName.ARCTANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
-    BuiltinFnName.ASIN: FunctionRule(r"\arcsin", is_unary=True),
-    BuiltinFnName.ASINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
-    BuiltinFnName.ATAN: FunctionRule(r"\arctan", is_unary=True),
-    BuiltinFnName.ATANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
-    BuiltinFnName.CEIL: FunctionRule(
+BUILTIN_FUNCS: dict[str, FunctionRule] = {
+    "abs": FunctionRule(r"\mathropen{}\left|", r"\mathclose{}\right|", is_wrapped=True),
+    "acos": FunctionRule(r"\arccos", is_unary=True),
+    "acosh": FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    "arccos": FunctionRule(r"\arccos", is_unary=True),
+    "arccosh": FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    "arcsin": FunctionRule(r"\arcsin", is_unary=True),
+    "arcsinh": FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    "arctan": FunctionRule(r"\arctan", is_unary=True),
+    "arctanh": FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    "asin": FunctionRule(r"\arcsin", is_unary=True),
+    "asinh": FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    "atan": FunctionRule(r"\arctan", is_unary=True),
+    "atanh": FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    "ceil": FunctionRule(
         r"\mathopen{}\left\lceil", r"\mathclose{}\right\rceil", is_wrapped=True
     ),
-    BuiltinFnName.COS: FunctionRule(r"\cos", is_unary=True),
-    BuiltinFnName.COSH: FunctionRule(r"\cosh", is_unary=True),
-    BuiltinFnName.EXP: FunctionRule(r"\exp", is_unary=True),
-    BuiltinFnName.FABS: FunctionRule(
-        r"\mathopen{}\left|", r"\mathclose{}\right|", is_wrapped=True
-    ),
-    BuiltinFnName.FACTORIAL: FunctionRule("", "!", is_unary=True),
-    BuiltinFnName.FLOOR: FunctionRule(
+    "cos": FunctionRule(r"\cos", is_unary=True),
+    "cosh": FunctionRule(r"\cosh", is_unary=True),
+    "exp": FunctionRule(r"\exp", is_unary=True),
+    "fabs": FunctionRule(r"\mathopen{}\left|", r"\mathclose{}\right|", is_wrapped=True),
+    "factorial": FunctionRule("", "!", is_unary=True),
+    "floor": FunctionRule(
         r"\mathopen{}\left\lfloor", r"\mathclose{}\right\rfloor", is_wrapped=True
     ),
-    BuiltinFnName.FSUM: FunctionRule(r"\sum", is_unary=True),
-    BuiltinFnName.GAMMA: FunctionRule(r"\Gamma"),
-    BuiltinFnName.LOG: FunctionRule(r"\log", is_unary=True),
-    BuiltinFnName.LOG10: FunctionRule(r"\log_10", is_unary=True),
-    BuiltinFnName.LOG2: FunctionRule(r"\log_2", is_unary=True),
-    BuiltinFnName.PROD: FunctionRule(r"\prod", is_unary=True),
-    BuiltinFnName.SIN: FunctionRule(r"\sin", is_unary=True),
-    BuiltinFnName.SINH: FunctionRule(r"\sinh", is_unary=True),
-    BuiltinFnName.SQRT: FunctionRule(r"\sqrt{", "}", is_wrapped=True),
-    BuiltinFnName.SUM: FunctionRule(r"\sum", is_unary=True),
-    BuiltinFnName.TAN: FunctionRule(r"\tan", is_unary=True),
-    BuiltinFnName.TANH: FunctionRule(r"\tanh", is_unary=True),
+    "fsum": FunctionRule(r"\sum", is_unary=True),
+    "gamma": FunctionRule(r"\Gamma"),
+    "log": FunctionRule(r"\log", is_unary=True),
+    "log10": FunctionRule(r"\log_10", is_unary=True),
+    "log2": FunctionRule(r"\log_2", is_unary=True),
+    "prod": FunctionRule(r"\prod", is_unary=True),
+    "sin": FunctionRule(r"\sin", is_unary=True),
+    "sinh": FunctionRule(r"\sinh", is_unary=True),
+    "sqrt": FunctionRule(r"\sqrt{", "}", is_wrapped=True),
+    "sum": FunctionRule(r"\sum", is_unary=True),
+    "tan": FunctionRule(r"\tan", is_unary=True),
+    "tanh": FunctionRule(r"\tanh", is_unary=True),
 }

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import dataclasses
-import enum
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/latexify/transformers/function_expander.py
+++ b/src/latexify/transformers/function_expander.py
@@ -4,7 +4,7 @@ import ast
 import functools
 from collections.abc import Callable
 
-from latexify import ast_utils, constants, exceptions
+from latexify import ast_utils, exceptions
 
 
 # TODO(ZibingZhang): handle mutually recursive function expansions
@@ -52,7 +52,7 @@ class FunctionExpander(ast.NodeTransformer):
 def _atan2_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.AST:
     _check_num_args(node, 2)
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.ATAN.value, ctx=ast.Load()),
+        func=ast.Name(id="atan", ctx=ast.Load()),
         args=[
             ast.BinOp(
                 left=function_expander.visit(node.args[0]),
@@ -86,7 +86,7 @@ def _expm1_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
     return ast.BinOp(
         left=function_expander.visit(
             ast.Call(
-                func=ast.Name(id=constants.BuiltinFnName.EXP.value, ctx=ast.Load()),
+                func=ast.Name(id="exp", ctx=ast.Load()),
                 args=[node.args[0]],
             )
         ),
@@ -112,7 +112,7 @@ def _hypot_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
         lambda a, b: ast.BinOp(left=a, op=ast.Add(), right=b), args
     )
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.SQRT.value, ctx=ast.Load()),
+        func=ast.Name(id="sqrt", ctx=ast.Load()),
         args=[args_reduced],
     )
 
@@ -120,7 +120,7 @@ def _hypot_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
 def _log1p_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.AST:
     _check_num_args(node, 1)
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.LOG.value, ctx=ast.Load()),
+        func=ast.Name(id="log", ctx=ast.Load()),
         args=[
             ast.BinOp(
                 left=ast_utils.make_constant(1),


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This change reverts `BuiltinFnName` enum.

CC: @ZibingZhang

# Details

`BuiltinFnName` was introduced by #130 to constrain keys in `BUILTIN_FUNCS`. I originally thought that it was useful, but after several development I realized that using raw string is more desirable:

- Enum introduces a strong type constraint. If I introduced mypy in my local environment, `BUILTIN_FUNCS` rejects all strings that are not defined in the `BuiltinFnName`, which is not a desirable behavior.
- We are required to write very long ientifiers, e.g., `constants.BuiltInFnName.EXP.value` rather than `"exp"`. The identifier also involves the same string `EXP` with the function name, meaning that we eventually need to write the function name with longer prefix every time.
- The enum is rarely used: in many cases the current implementation keeps the string representation.


# References

- NA

# Blocked by

- NA
