### PR TITLE
Enable mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,17 @@ jobs:
           python -m pip install isort
       - name: Check
         run: python -m isort --check src
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install mypy
+      - name: Check
+        run: python -m mypy src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install mypy
+          python -m pip install '.[mypy]'
       - name: Check
         run: python -m mypy src

--- a/checks.sh
+++ b/checks.sh
@@ -5,3 +5,4 @@ python -m pytest src -vv
 python -m black --check src
 python -m pflake8 src
 python -m isort --check src
+python -m mypy src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,12 @@ dev = [
     "build>=0.8",
     "black>=22.10",
     "flake8>=5.0",
+    "isort>=5.10",
+    "mypy>=0.991",
     "notebook>=6.5.1",
     "pyproject-flake8>=5.0",
     "pytest>=7.1",
     "twine>=4.0",
-    "isort>=5.10",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dev = [
     "pytest>=7.1",
     "twine>=4.0",
 ]
+mypy = [
+    "mypy>=0.991",
+    "pytest>=7.1",
+]
 
 [project.urls]
 Homepage = "https://github.com/google/latexify_py"

--- a/src/latexify/__init__.py
+++ b/src/latexify/__init__.py
@@ -13,6 +13,3 @@ get_latex = frontend.get_latex
 
 function = frontend.function
 expression = frontend.expression
-
-# Deprecated
-with_latex = frontend.with_latex

--- a/src/latexify/ast_utils_test.py
+++ b/src/latexify/ast_utils_test.py
@@ -121,15 +121,6 @@ def test_extract_int_or_none() -> None:
 
 
 def test_extract_int_or_none_invalid() -> None:
-    # Not a subtree.
-    assert ast_utils.extract_int_or_none(123) is None
-
-    # Not a direct Constant node.
-    assert (
-        ast_utils.extract_int_or_none(ast.Expr(value=ast_utils.make_constant(123)))
-        is None
-    )
-
     # Not a Constant node with int.
     assert ast_utils.extract_int_or_none(ast_utils.make_constant(None)) is None
     assert ast_utils.extract_int_or_none(ast_utils.make_constant(True)) is None
@@ -147,14 +138,6 @@ def test_extract_int() -> None:
 
 
 def test_extract_int_invalid() -> None:
-    # Not a subtree.
-    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
-        ast_utils.extract_int(123)
-
-    # Not a direct Constant node.
-    with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
-        ast_utils.extract_int(ast.Expr(value=ast_utils.make_constant(123)))
-
     # Not a Constant node with int.
     with pytest.raises(ValueError, match=r"^Unsupported node to extract int"):
         ast_utils.extract_int(ast_utils.make_constant(None))

--- a/src/latexify/codegen/latex.py
+++ b/src/latexify/codegen/latex.py
@@ -21,7 +21,7 @@ class Latex:
         """
         self._raw = raw
 
-    def __eq__(self, other: object) -> None:
+    def __eq__(self, other: object) -> bool:
         """Checks equality.
 
         Args:

--- a/src/latexify/constants.py
+++ b/src/latexify/constants.py
@@ -6,43 +6,6 @@ import dataclasses
 import enum
 
 
-class BuiltinFnName(str, enum.Enum):
-    """Built-in function name."""
-
-    ABS = "abs"
-    ACOS = "acos"
-    ACOSH = "acosh"
-    ARCCOS = "arccos"
-    ARCCOSH = "arcosh"
-    ARCSIN = "arcsin"
-    ARCSINH = "arcsihn"
-    ARCTAN = "arctan"
-    ARCTANH = "arctanh"
-    ASIN = "asin"
-    ASINH = "asinh"
-    ATAN = "atan"
-    ATANH = "atanh"
-    CEIL = "ceil"
-    COS = "cos"
-    COSH = "cosh"
-    EXP = "exp"
-    FABS = "fabs"
-    FACTORIAL = "factorial"
-    FLOOR = "floor"
-    FSUM = "fsum"
-    GAMMA = "gamma"
-    LOG = "log"
-    LOG10 = "log10"
-    LOG2 = "log2"
-    PROD = "prod"
-    SIN = "sin"
-    SINH = "sinh"
-    SQRT = "sqrt"
-    TAN = "tan"
-    TANH = "tanh"
-    SUM = "sum"
-
-
 @dataclasses.dataclass(frozen=True)
 class FunctionRule:
     """Codegen rules for functions.
@@ -61,45 +24,41 @@ class FunctionRule:
 
 
 # name => left_syntax, right_syntax, is_wrapped
-BUILTIN_FUNCS: dict[BuiltinFnName, FunctionRule] = {
-    BuiltinFnName.ABS: FunctionRule(
-        r"\mathropen{}\left|", r"\mathclose{}\right|", is_wrapped=True
-    ),
-    BuiltinFnName.ACOS: FunctionRule(r"\arccos", is_unary=True),
-    BuiltinFnName.ACOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
-    BuiltinFnName.ARCCOS: FunctionRule(r"\arccos", is_unary=True),
-    BuiltinFnName.ARCCOSH: FunctionRule(r"\mathrm{arccosh}", is_unary=True),
-    BuiltinFnName.ARCSIN: FunctionRule(r"\arcsin", is_unary=True),
-    BuiltinFnName.ARCSINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
-    BuiltinFnName.ARCTAN: FunctionRule(r"\arctan", is_unary=True),
-    BuiltinFnName.ARCTANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
-    BuiltinFnName.ASIN: FunctionRule(r"\arcsin", is_unary=True),
-    BuiltinFnName.ASINH: FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
-    BuiltinFnName.ATAN: FunctionRule(r"\arctan", is_unary=True),
-    BuiltinFnName.ATANH: FunctionRule(r"\mathrm{arctanh}", is_unary=True),
-    BuiltinFnName.CEIL: FunctionRule(
+BUILTIN_FUNCS: dict[str, FunctionRule] = {
+    "abs": FunctionRule(r"\mathropen{}\left|", r"\mathclose{}\right|", is_wrapped=True),
+    "acos": FunctionRule(r"\arccos", is_unary=True),
+    "acosh": FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    "arccos": FunctionRule(r"\arccos", is_unary=True),
+    "arccosh": FunctionRule(r"\mathrm{arccosh}", is_unary=True),
+    "arcsin": FunctionRule(r"\arcsin", is_unary=True),
+    "arcsinh": FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    "arctan": FunctionRule(r"\arctan", is_unary=True),
+    "arctanh": FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    "asin": FunctionRule(r"\arcsin", is_unary=True),
+    "asinh": FunctionRule(r"\mathrm{arcsinh}", is_unary=True),
+    "atan": FunctionRule(r"\arctan", is_unary=True),
+    "atanh": FunctionRule(r"\mathrm{arctanh}", is_unary=True),
+    "ceil": FunctionRule(
         r"\mathopen{}\left\lceil", r"\mathclose{}\right\rceil", is_wrapped=True
     ),
-    BuiltinFnName.COS: FunctionRule(r"\cos", is_unary=True),
-    BuiltinFnName.COSH: FunctionRule(r"\cosh", is_unary=True),
-    BuiltinFnName.EXP: FunctionRule(r"\exp", is_unary=True),
-    BuiltinFnName.FABS: FunctionRule(
-        r"\mathopen{}\left|", r"\mathclose{}\right|", is_wrapped=True
-    ),
-    BuiltinFnName.FACTORIAL: FunctionRule("", "!", is_unary=True),
-    BuiltinFnName.FLOOR: FunctionRule(
+    "cos": FunctionRule(r"\cos", is_unary=True),
+    "cosh": FunctionRule(r"\cosh", is_unary=True),
+    "exp": FunctionRule(r"\exp", is_unary=True),
+    "fabs": FunctionRule(r"\mathopen{}\left|", r"\mathclose{}\right|", is_wrapped=True),
+    "factorial": FunctionRule("", "!", is_unary=True),
+    "floor": FunctionRule(
         r"\mathopen{}\left\lfloor", r"\mathclose{}\right\rfloor", is_wrapped=True
     ),
-    BuiltinFnName.FSUM: FunctionRule(r"\sum", is_unary=True),
-    BuiltinFnName.GAMMA: FunctionRule(r"\Gamma"),
-    BuiltinFnName.LOG: FunctionRule(r"\log", is_unary=True),
-    BuiltinFnName.LOG10: FunctionRule(r"\log_10", is_unary=True),
-    BuiltinFnName.LOG2: FunctionRule(r"\log_2", is_unary=True),
-    BuiltinFnName.PROD: FunctionRule(r"\prod", is_unary=True),
-    BuiltinFnName.SIN: FunctionRule(r"\sin", is_unary=True),
-    BuiltinFnName.SINH: FunctionRule(r"\sinh", is_unary=True),
-    BuiltinFnName.SQRT: FunctionRule(r"\sqrt{", "}", is_wrapped=True),
-    BuiltinFnName.SUM: FunctionRule(r"\sum", is_unary=True),
-    BuiltinFnName.TAN: FunctionRule(r"\tan", is_unary=True),
-    BuiltinFnName.TANH: FunctionRule(r"\tanh", is_unary=True),
+    "fsum": FunctionRule(r"\sum", is_unary=True),
+    "gamma": FunctionRule(r"\Gamma"),
+    "log": FunctionRule(r"\log", is_unary=True),
+    "log10": FunctionRule(r"\log_10", is_unary=True),
+    "log2": FunctionRule(r"\log_2", is_unary=True),
+    "prod": FunctionRule(r"\prod", is_unary=True),
+    "sin": FunctionRule(r"\sin", is_unary=True),
+    "sinh": FunctionRule(r"\sinh", is_unary=True),
+    "sqrt": FunctionRule(r"\sqrt{", "}", is_wrapped=True),
+    "sum": FunctionRule(r"\sum", is_unary=True),
+    "tan": FunctionRule(r"\tan", is_unary=True),
+    "tanh": FunctionRule(r"\tanh", is_unary=True),
 }

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from typing import Any, overload
 

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import Any, overload
 
 from latexify import codegen
 from latexify import config as cfg
@@ -119,45 +119,63 @@ class LatexifiedFunction:
         )
 
 
-def function(*args, **kwargs) -> Callable[[Callable[..., Any]], LatexifiedFunction]:
-    """Translate a function into a corresponding LaTeX representation.
+@overload
+def function(fn: Callable[..., Any], **kwargs: Any) -> LatexifiedFunction:
+    ...
+
+
+@overload
+def function(**kwargs: Any) -> Callable[[Callable[..., Any]], LatexifiedFunction]:
+    ...
+
+
+def function(
+    fn: Callable[..., Any] | None = None, **kwargs: Any
+) -> LatexifiedFunction | Callable[[Callable[..., Any]], LatexifiedFunction]:
+    """Attach LaTeX pretty-printing to the given function.
 
     This function works with or without specifying the target function as the positional
     argument. The following two syntaxes works similarly.
-        - with_latex(fn, **kwargs)
-        - with_latex(**kwargs)(fn)
+        - latexify.function(fn, **kwargs)
+        - latexify.function(**kwargs)(fn)
 
     Args:
-        *args: No argument, or a callable.
+        fn: Callable to be wrapped.
         **kwargs: Arguments to control behavior. See also get_latex().
 
     Returns:
-        - If the target function is passed directly, returns the wrapped function.
+        - If `fn` is passed, returns the wrapped function.
         - Otherwise, returns the wrapper function with given settings.
     """
-    if len(args) == 1 and isinstance(args[0], Callable):
-        return LatexifiedFunction(args[0], **kwargs)
-
-    def wrapper(fn):
+    if fn is not None:
         return LatexifiedFunction(fn, **kwargs)
+
+    def wrapper(f):
+        return LatexifiedFunction(f, **kwargs)
 
     return wrapper
 
 
-def expression(*args, **kwargs) -> Callable[[Callable[..., Any]], LatexifiedFunction]:
-    """Translate a function into a LaTeX representation without the signature.
+@overload
+def expression(fn: Callable[..., Any], **kwargs: Any) -> LatexifiedFunction:
+    ...
+
+
+@overload
+def expression(**kwargs: Any) -> Callable[[Callable[..., Any]], LatexifiedFunction]:
+    ...
+
+
+def expression(
+    fn: Callable[..., Any] | None = None, **kwargs: Any
+) -> LatexifiedFunction | Callable[[Callable[..., Any]], LatexifiedFunction]:
+    """Attach LaTeX pretty-printing to the given function.
 
     This function is a shortcut for `latexify.function` with the default parameter
     `use_signature=False`.
     """
     kwargs["use_signature"] = kwargs.get("use_signature", False)
-    return function(*args, **kwargs)
-
-
-def with_latex(*args, **kwargs) -> Callable[[Callable[..., Any]], LatexifiedFunction]:
-    """Deprecated. use `latexify.function` instead."""
-    warnings.warn(
-        "`latexify.with_latex` is deprecated. Use `latexify.function` instead.",
-        DeprecationWarning,
-    )
-    return function(*args, **kwargs)
+    if fn is not None:
+        return function(fn, **kwargs)
+    else:
+        return function(**kwargs)

--- a/src/latexify/parser.py
+++ b/src/latexify/parser.py
@@ -8,12 +8,12 @@ import textwrap
 from collections.abc import Callable
 from typing import Any
 
-import dill
+import dill  # type: ignore[import]
 
 from latexify import exceptions
 
 
-def parse_function(fn: Callable[..., Any]) -> ast.FunctionDef:
+def parse_function(fn: Callable[..., Any]) -> ast.Module:
     """Parses given function.
 
     Args:

--- a/src/latexify/transformers/__init__.py
+++ b/src/latexify/transformers/__init__.py
@@ -6,8 +6,8 @@ from latexify.transformers.identifier_replacer import IdentifierReplacer
 from latexify.transformers.prefix_trimmer import PrefixTrimmer
 
 __all__ = [
-    AssignmentReducer,
-    FunctionExpander,
-    IdentifierReplacer,
-    PrefixTrimmer,
+    "AssignmentReducer",
+    "FunctionExpander",
+    "IdentifierReplacer",
+    "PrefixTrimmer",
 ]

--- a/src/latexify/transformers/function_expander.py
+++ b/src/latexify/transformers/function_expander.py
@@ -52,7 +52,7 @@ class FunctionExpander(ast.NodeTransformer):
 def _atan2_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.AST:
     _check_num_args(node, 2)
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.ATAN.value, ctx=ast.Load()),
+        func=ast.Name(id="atan", ctx=ast.Load()),
         args=[
             ast.BinOp(
                 left=function_expander.visit(node.args[0]),
@@ -86,7 +86,7 @@ def _expm1_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
     return ast.BinOp(
         left=function_expander.visit(
             ast.Call(
-                func=ast.Name(id=constants.BuiltinFnName.EXP.value, ctx=ast.Load()),
+                func=ast.Name(id="exp", ctx=ast.Load()),
                 args=[node.args[0]],
             )
         ),
@@ -112,7 +112,7 @@ def _hypot_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
         lambda a, b: ast.BinOp(left=a, op=ast.Add(), right=b), args
     )
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.SQRT.value, ctx=ast.Load()),
+        func=ast.Name(id="sqrt", ctx=ast.Load()),
         args=[args_reduced],
     )
 
@@ -120,7 +120,7 @@ def _hypot_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.
 def _log1p_expander(function_expander: FunctionExpander, node: ast.Call) -> ast.AST:
     _check_num_args(node, 1)
     return ast.Call(
-        func=ast.Name(id=constants.BuiltinFnName.LOG.value, ctx=ast.Load()),
+        func=ast.Name(id="log", ctx=ast.Load()),
         args=[
             ast.BinOp(
                 left=ast_utils.make_constant(1),

--- a/src/latexify/transformers/identifier_replacer.py
+++ b/src/latexify/transformers/identifier_replacer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 import re
 import sys
-from typing import ClassVar
+from typing import ClassVar, cast
 
 
 class IdentifierReplacer(ast.NodeTransformer):
@@ -47,33 +47,32 @@ class IdentifierReplacer(ast.NodeTransformer):
         """Helper function to replace arg names."""
         return [ast.arg(arg=self._mapping.get(a.arg, a.arg)) for a in args]
 
-    def _visit_children(self, children: list[ast.AST]) -> list[ast.AST]:
-        """Helper function to visit all children."""
-        return [self.visit(child) for child in children]
-
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
         """Visitor of FunctionDef."""
+
+        visited = cast(ast.FunctionDef, super().generic_visit(node))
+
         if sys.version_info.minor < 8:
             args = ast.arguments(
-                args=self._replace_args(node.args.args),
-                kwonlyargs=self._replace_args(node.args.kwonlyargs),
-                kw_defaults=self._visit_children(node.args.kw_defaults),
-                defaults=self._visit_children(node.args.defaults),
+                args=self._replace_args(visited.args.args),
+                kwonlyargs=self._replace_args(visited.args.kwonlyargs),
+                kw_defaults=visited.args.kw_defaults,
+                defaults=visited.args.defaults,
             )
         else:
             args = ast.arguments(
-                posonlyargs=self._replace_args(node.args.posonlyargs),  # from 3.8
-                args=self._replace_args(node.args.args),
-                kwonlyargs=self._replace_args(node.args.kwonlyargs),
-                kw_defaults=self._visit_children(node.args.kw_defaults),
-                defaults=self._visit_children(node.args.defaults),
+                posonlyargs=self._replace_args(visited.args.posonlyargs),  # from 3.8
+                args=self._replace_args(visited.args.args),
+                kwonlyargs=self._replace_args(visited.args.kwonlyargs),
+                kw_defaults=visited.args.kw_defaults,
+                defaults=visited.args.defaults,
             )
 
         return ast.FunctionDef(
-            name=self._mapping.get(node.name, node.name),
+            name=self._mapping.get(visited.name, visited.name),
             args=args,
-            body=self._visit_children(node.body),
-            decorator_list=self._visit_children(node.decorator_list),
+            body=visited.body,
+            decorator_list=visited.decorator_list,
         )
 
     def visit_Name(self, node: ast.Name) -> ast.Name:


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Introduces mypy as a new CI. Also fixes several typing errors discovered by the non-strict mode of mypy.

This change removes the deprecated `with_latex`, which is no longer useful to support (especially with  correct type hints).

# References

NA

# Blocked by

- #151
