### PR TITLE
remove common prefixes.

### DIFF
--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -10,12 +10,6 @@ from latexify import codegen
 from latexify import config as cfg
 from latexify import exceptions, parser, transformers
 
-# NOTE(odashi):
-# These prefixes are trimmed by default.
-# This behavior shouldn't be controlled by users in the current implementation because
-# some processes expects absense of these prefixes.
-_COMMON_PREFIXES = {"math", "numpy", "np"}
-
 
 class Style(enum.Enum):
     EXPRESSION = "expression"
@@ -56,9 +50,8 @@ def get_latex(
 
     # Applies AST transformations.
 
-    prefixes = _COMMON_PREFIXES | (merged_config.prefixes or set())
-    tree = transformers.PrefixTrimmer(prefixes).visit(tree)
-
+    if merged_config.prefixes is not None:
+        tree = transformers.PrefixTrimmer(merged_config.prefixes).visit(tree)
     if merged_config.identifiers is not None:
         tree = transformers.IdentifierReplacer(merged_config.identifiers).visit(tree)
     if merged_config.reduce_assignments:

--- a/src/latexify/frontend_test.py
+++ b/src/latexify/frontend_test.py
@@ -19,16 +19,16 @@ def test_get_latex_identifiers() -> None:
 
 
 def test_get_latex_prefixes() -> None:
-    math = numpy = np = abc = object()
+    abc = object()
 
     def f(x):
-        return math.a + numpy.b + np.c + abc.d + x.y.z.e
+        return abc.d + x.y.z.e
 
-    latex_without_flag = r"f(x) = a + b + c + \mathrm{abc}.d + x.y.z.e"
-    latex_with_flag1 = r"f(x) = a + b + c + d + x.y.z.e"
-    latex_with_flag2 = r"f(x) = a + b + c + \mathrm{abc}.d + y.z.e"
-    latex_with_flag3 = r"f(x) = a + b + c + \mathrm{abc}.d + z.e"
-    latex_with_flag4 = r"f(x) = a + b + c + d + e"
+    latex_without_flag = r"f(x) = \mathrm{abc}.d + x.y.z.e"
+    latex_with_flag1 = r"f(x) = d + x.y.z.e"
+    latex_with_flag2 = r"f(x) = \mathrm{abc}.d + y.z.e"
+    latex_with_flag3 = r"f(x) = \mathrm{abc}.d + z.e"
+    latex_with_flag4 = r"f(x) = d + e"
 
     assert frontend.get_latex(f) == latex_without_flag
     assert frontend.get_latex(f, prefixes=set()) == latex_without_flag


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Removes common prefix behavior. This was somewhat weird, and now does not affect most of the current implementation.

CC @ZibingZhang 

# References

- https://github.com/google/latexify_py/issues/88#issuecomment-1345545885

# Blocked by

- NA
