### PR TITLE
Improve algorithmic codegen, return multiline string

### DIFF
--- a/src/integration_tests/algorithmic_style_test.py
+++ b/src/integration_tests/algorithmic_style_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 from typing import Any, Callable
 
 from latexify import frontend
@@ -34,17 +35,21 @@ def test_factorial() -> None:
         else:
             return n * fact(n - 1)
 
-    latex = (
-        r"\begin{algorithmic}"
-        r" \Function{fact}{$n$}"
-        r" \If{$n = 0$}"
-        r" \State \Return $1$"
-        r" \Else"
-        r" \State \Return $n \mathrm{fact} \mathopen{}\left( n - 1 \mathclose{}\right)$"
-        r" \EndIf"
-        r" \EndFunction"
-        r" \end{algorithmic}"
-    )
+    # noqa: E501
+    latex = textwrap.dedent(
+        r"""
+        \begin{algorithmic}
+            \Function{fact}{$n$}
+                \If{$n = 0$}
+                    \State \Return $1$
+                \Else
+                    \State \Return $n \mathrm{fact} \mathopen{}\left( n - 1 \mathclose{}\right)$
+                \EndIf
+            \EndFunction
+        \end{algorithmic}
+        """  # noqa: E501
+    ).strip()
+
     check_algorithm(fact, latex)
 
 
@@ -59,19 +64,22 @@ def test_collatz() -> None:
             iterations = iterations + 1
         return iterations
 
-    latex = (
-        r"\begin{algorithmic}"
-        r" \Function{collatz}{$n$}"
-        r" \State $\mathrm{iterations} \gets 0$"
-        r" \While{$n > 1$}"
-        r" \If{$n \mathbin{\%} 2 = 0$}"
-        r" \State $n \gets \left\lfloor\frac{n}{2}\right\rfloor$"
-        r" \Else \State $n \gets 3 n + 1$"
-        r" \EndIf"
-        r" \State $\mathrm{iterations} \gets \mathrm{iterations} + 1$"
-        r" \EndWhile"
-        r" \State \Return $\mathrm{iterations}$"
-        r" \EndFunction"
-        r" \end{algorithmic}"
-    )
+    latex = textwrap.dedent(
+        r"""
+        \begin{algorithmic}
+            \Function{collatz}{$n$}
+                \State $\mathrm{iterations} \gets 0$
+                \While{$n > 1$}
+                    \If{$n \mathbin{\%} 2 = 0$}
+                        \State $n \gets \left\lfloor\frac{n}{2}\right\rfloor$
+                    \Else
+                        \State $n \gets 3 n + 1$
+                    \EndIf
+                    \State $\mathrm{iterations} \gets \mathrm{iterations} + 1$
+                \EndWhile
+                \State \Return $\mathrm{iterations}$
+            \EndFunction
+        \end{algorithmic}
+        """
+    ).strip()
     check_algorithm(collatz, latex)

--- a/src/integration_tests/algorithmic_style_test.py
+++ b/src/integration_tests/algorithmic_style_test.py
@@ -35,7 +35,6 @@ def test_factorial() -> None:
         else:
             return n * fact(n - 1)
 
-    # noqa: E501
     latex = textwrap.dedent(
         r"""
         \begin{algorithmic}

--- a/src/latexify/codegen/algorithmic_codegen.py
+++ b/src/latexify/codegen/algorithmic_codegen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 import contextlib
-from typing import Generator
+from collections.abc import Generator
 
 from latexify import exceptions
 from latexify.codegen import expression_codegen, identifier_converter

--- a/src/latexify/codegen/algorithmic_codegen.py
+++ b/src/latexify/codegen/algorithmic_codegen.py
@@ -68,37 +68,33 @@ class AlgorithmicCodegen(ast.NodeVisitor):
         ]
 
         latex = self._add_indent("\\begin{algorithmic}\n")
-        self._indent_level += 1
-        latex += self._add_indent(
-            f"\\Function{{{node.name}}}{{${', '.join(arg_strs)}$}}\n"
-        )
+        with self._increment_level():
+            latex += self._add_indent(
+                f"\\Function{{{node.name}}}{{${', '.join(arg_strs)}$}}\n"
+            )
 
-        # Body
-        self._indent_level += 1
-        body_strs: list[str] = [self.visit(stmt) for stmt in node.body]
-        self._indent_level -= 1
-        body_latex = "\n".join(body_strs)
+            with self._increment_level():
+                # Body
+                body_strs: list[str] = [self.visit(stmt) for stmt in node.body]
+            body_latex = "\n".join(body_strs)
 
-        latex += f"{body_latex}\n"
-        latex += self._add_indent("\\EndFunction\n")
-        self._indent_level -= 1
+            latex += f"{body_latex}\n"
+            latex += self._add_indent("\\EndFunction\n")
         return latex + self._add_indent(r"\end{algorithmic}")
 
     # TODO(ZibingZhang): support \ELSIF
     def visit_If(self, node: ast.If) -> str:
         """Visit an If node."""
         cond_latex = self._expression_codegen.visit(node.test)
-        self._indent_level += 1
-        body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
-        self._indent_level -= 1
+        with self._increment_level():
+            body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
 
         latex = self._add_indent(f"\\If{{${cond_latex}$}}\n{body_latex}")
 
         if node.orelse:
             latex += "\n" + self._add_indent(r"\Else") + "\n"
-            self._indent_level += 1
-            latex += "\n".join(self.visit(stmt) for stmt in node.orelse)
-            self._indent_level -= 1
+            with self._increment_level():
+                latex += "\n".join(self.visit(stmt) for stmt in node.orelse)
 
         return latex + "\n" + self._add_indent(r"\EndIf")
 
@@ -124,9 +120,8 @@ class AlgorithmicCodegen(ast.NodeVisitor):
             )
 
         cond_latex = self._expression_codegen.visit(node.test)
-        self._indent_level += 1
-        body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
-        self._indent_level -= 1
+        with self._increment_level():
+            body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
         return (
             self._add_indent(f"\\While{{${cond_latex}$}}\n")
             + f"{body_latex}\n"

--- a/src/latexify/codegen/algorithmic_codegen.py
+++ b/src/latexify/codegen/algorithmic_codegen.py
@@ -64,7 +64,6 @@ class AlgorithmicCodegen(ast.NodeVisitor):
         ]
 
         latex = f"{self._prefix()}\\begin{{algorithmic}}\n"
-
         self._indent += 1
         latex += (
             f"{self._prefix()}\\Function{{{node.name}}}{{${', '.join(arg_strs)}$}}\n"
@@ -78,7 +77,6 @@ class AlgorithmicCodegen(ast.NodeVisitor):
 
         latex += f"{body_latex}\n{self._prefix()}\\EndFunction\n"
         self._indent -= 1
-
         return latex + rf"{self._prefix()}\end{{algorithmic}}"
 
     # TODO(ZibingZhang): support \ELSIF

--- a/src/latexify/codegen/algorithmic_codegen.py
+++ b/src/latexify/codegen/algorithmic_codegen.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import contextlib
+from typing import Generator
 
 from latexify import exceptions
 from latexify.codegen import expression_codegen, identifier_converter
@@ -18,7 +20,7 @@ class AlgorithmicCodegen(ast.NodeVisitor):
     _SPACES_PER_INDENT = 4
 
     _identifier_converter: identifier_converter.IdentifierConverter
-    _indent: int
+    _indent_level: int
 
     def __init__(
         self, *, use_math_symbols: bool = False, use_set_symbols: bool = False
@@ -36,7 +38,7 @@ class AlgorithmicCodegen(ast.NodeVisitor):
         self._identifier_converter = identifier_converter.IdentifierConverter(
             use_math_symbols=use_math_symbols
         )
-        self._indent = 0
+        self._indent_level = 0
 
     def generic_visit(self, node: ast.AST) -> str:
         raise exceptions.LatexifyNotSupportedError(
@@ -50,11 +52,13 @@ class AlgorithmicCodegen(ast.NodeVisitor):
         ]
         operands.append(self._expression_codegen.visit(node.value))
         operands_latex = r" \gets ".join(operands)
-        return rf"{self._prefix()}\State ${operands_latex}$"
+        return self._add_indent(rf"\State ${operands_latex}$")
 
     def visit_Expr(self, node: ast.Expr) -> str:
         """Visit an Expr node."""
-        return rf"{self._prefix()}\State ${self._expression_codegen.visit(node.value)}$"
+        return self._add_indent(
+            rf"\State ${self._expression_codegen.visit(node.value)}$"
+        )
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> str:
         """Visit a FunctionDef node."""
@@ -63,39 +67,40 @@ class AlgorithmicCodegen(ast.NodeVisitor):
             self._identifier_converter.convert(arg.arg)[0] for arg in node.args.args
         ]
 
-        latex = f"{self._prefix()}\\begin{{algorithmic}}\n"
-        self._indent += 1
-        latex += (
-            f"{self._prefix()}\\Function{{{node.name}}}{{${', '.join(arg_strs)}$}}\n"
+        latex = self._add_indent("\\begin{algorithmic}\n")
+        self._indent_level += 1
+        latex += self._add_indent(
+            f"\\Function{{{node.name}}}{{${', '.join(arg_strs)}$}}\n"
         )
 
         # Body
-        self._indent += 1
+        self._indent_level += 1
         body_strs: list[str] = [self.visit(stmt) for stmt in node.body]
-        self._indent -= 1
+        self._indent_level -= 1
         body_latex = "\n".join(body_strs)
 
-        latex += f"{body_latex}\n{self._prefix()}\\EndFunction\n"
-        self._indent -= 1
-        return latex + rf"{self._prefix()}\end{{algorithmic}}"
+        latex += f"{body_latex}\n"
+        latex += self._add_indent("\\EndFunction\n")
+        self._indent_level -= 1
+        return latex + self._add_indent(r"\end{algorithmic}")
 
     # TODO(ZibingZhang): support \ELSIF
     def visit_If(self, node: ast.If) -> str:
         """Visit an If node."""
         cond_latex = self._expression_codegen.visit(node.test)
-        self._indent += 1
+        self._indent_level += 1
         body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
-        self._indent -= 1
+        self._indent_level -= 1
 
-        latex = f"{self._prefix()}\\If{{${cond_latex}$}}\n{body_latex}"
+        latex = self._add_indent(f"\\If{{${cond_latex}$}}\n{body_latex}")
 
         if node.orelse:
-            latex += f"\n{self._prefix()}\\Else\n"
-            self._indent += 1
+            latex += "\n" + self._add_indent(r"\Else") + "\n"
+            self._indent_level += 1
             latex += "\n".join(self.visit(stmt) for stmt in node.orelse)
-            self._indent -= 1
+            self._indent_level -= 1
 
-        return latex + f"\n{self._prefix()}\\EndIf"
+        return latex + "\n" + self._add_indent(r"\EndIf")
 
     def visit_Module(self, node: ast.Module) -> str:
         """Visit a Module node."""
@@ -104,12 +109,11 @@ class AlgorithmicCodegen(ast.NodeVisitor):
     def visit_Return(self, node: ast.Return) -> str:
         """Visit a Return node."""
         return (
-            (
-                rf"{self._prefix()}\State \Return"
-                f" ${self._expression_codegen.visit(node.value)}$"
+            self._add_indent(
+                rf"\State \Return ${self._expression_codegen.visit(node.value)}$"
             )
             if node.value is not None
-            else rf"{self._prefix()}\State \Return"
+            else self._add_indent(r"\State \Return")
         )
 
     def visit_While(self, node: ast.While) -> str:
@@ -120,14 +124,26 @@ class AlgorithmicCodegen(ast.NodeVisitor):
             )
 
         cond_latex = self._expression_codegen.visit(node.test)
-        self._indent += 1
+        self._indent_level += 1
         body_latex = "\n".join(self.visit(stmt) for stmt in node.body)
-        self._indent -= 1
+        self._indent_level -= 1
         return (
-            f"{self._prefix()}\\While{{${cond_latex}$}}\n"
-            f"{body_latex}\n"
-            rf"{self._prefix()}\EndWhile"
+            self._add_indent(f"\\While{{${cond_latex}$}}\n")
+            + f"{body_latex}\n"
+            + self._add_indent(r"\EndWhile")
         )
 
-    def _prefix(self) -> str:
-        return self._indent * self._SPACES_PER_INDENT * " "
+    @contextlib.contextmanager
+    def _increment_level(self) -> Generator[None, None, None]:
+        """Context manager controlling indent level."""
+        self._indent_level += 1
+        yield
+        self._indent_level -= 1
+
+    def _add_indent(self, line: str) -> str:
+        """Adds whitespace before the line.
+
+        Args:
+            line: The line to add whitespace to.
+        """
+        return self._indent_level * self._SPACES_PER_INDENT * " " + line

--- a/src/latexify/codegen/algorithmic_codegen_test.py
+++ b/src/latexify/codegen/algorithmic_codegen_test.py
@@ -25,8 +25,14 @@ def test_generic_visit() -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("x = 3", r"\State $x \gets 3$"),
-        ("a = b = 0", r"\State $a \gets b \gets 0$"),
+        (
+            "x = 3",
+            r"\State $x \gets 3$",
+        ),
+        (
+            "a = b = 0",
+            r"\State $a \gets b \gets 0$",
+        ),
     ],
 )
 def test_visit_assign(code: str, latex: str) -> None:
@@ -40,46 +46,65 @@ def test_visit_assign(code: str, latex: str) -> None:
     [
         (
             "def f(x): return x",
-            (
-                r"\begin{algorithmic}"
-                r" \Function{f}{$x$}"
-                r" \State \Return $x$"
-                r" \EndFunction"
-                r" \end{algorithmic}"
-            ),
+            r"""
+            \begin{algorithmic}
+                \Function{f}{$x$}
+                    \State \Return $x$
+                \EndFunction
+            \end{algorithmic}
+            """,
         ),
         (
             "def xyz(a, b, c): return 3",
-            (
-                r"\begin{algorithmic}"
-                r" \Function{xyz}{$a, b, c$}"
-                r" \State \Return $3$"
-                r" \EndFunction"
-                r" \end{algorithmic}"
-            ),
+            r"""
+            \begin{algorithmic}
+                \Function{xyz}{$a, b, c$}
+                    \State \Return $3$
+                \EndFunction
+            \end{algorithmic}
+            """,
         ),
     ],
 )
 def test_visit_functiondef(code: str, latex: str) -> None:
     node = ast.parse(textwrap.dedent(code)).body[0]
     assert isinstance(node, ast.FunctionDef)
-    assert algorithmic_codegen.AlgorithmicCodegen().visit(node) == latex
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == textwrap.dedent(latex).strip()
+    )
 
 
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("if x < y: return x", r"\If{$x < y$} \State \Return $x$ \EndIf"),
+        (
+            "if x < y: return x",
+            r"""
+            \If{$x < y$}
+                \State \Return $x$
+            \EndIf
+            """,
+        ),
         (
             "if True: x\nelse: y",
-            r"\If{$\mathrm{True}$} \State $x$ \Else \State $y$ \EndIf",
+            r"""
+            \If{$\mathrm{True}$}
+                \State $x$
+            \Else
+                \State $y$
+            \EndIf
+            """,
         ),
     ],
 )
 def test_visit_if(code: str, latex: str) -> None:
-    node = ast.parse(textwrap.dedent(code)).body[0]
+    node = ast.parse(code).body[0]
     assert isinstance(node, ast.If)
-    assert algorithmic_codegen.AlgorithmicCodegen().visit(node) == latex
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == textwrap.dedent(latex).strip()
+    )
 
 
 @pytest.mark.parametrize(
@@ -96,7 +121,7 @@ def test_visit_if(code: str, latex: str) -> None:
     ],
 )
 def test_visit_return(code: str, latex: str) -> None:
-    node = ast.parse(textwrap.dedent(code)).body[0]
+    node = ast.parse(code).body[0]
     assert isinstance(node, ast.Return)
     assert algorithmic_codegen.AlgorithmicCodegen().visit(node) == latex
 
@@ -106,14 +131,21 @@ def test_visit_return(code: str, latex: str) -> None:
     [
         (
             "while x < y: x = x + 1",
-            r"\While{$x < y$} \State $x \gets x + 1$ \EndWhile",
+            r"""
+            \While{$x < y$}
+                \State $x \gets x + 1$
+            \EndWhile
+            """,
         )
     ],
 )
 def test_visit_while(code: str, latex: str) -> None:
-    node = ast.parse(textwrap.dedent(code)).body[0]
+    node = ast.parse(code).body[0]
     assert isinstance(node, ast.While)
-    assert algorithmic_codegen.AlgorithmicCodegen().visit(node) == latex
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == textwrap.dedent(latex).strip()
+    )
 
 
 def test_visit_while_with_else() -> None:


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

Algorithmic codegen now returns a multiline string instead of a very long single line string.

# Details

<!-- EDIT HERE IF ANY:
Write a detailed description of this change.
This section should include all changed introduced by this pull request.
It is also recommended to describe the backgrounds, approaches, and any other
information related to the pull request.
-->

We keep track of our indentation level as we traverse through the AST.

### Example

old
```text
\If{$x < y$} \State \Return $x$ \EndIf
```

new
```text
If{$x < y$}
    \State \Return $x$
\EndIf
```

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

https://github.com/google/latexify_py/issues/57

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->

None
