### PR TITLE
Remove EXPRESSION style

### DIFF
--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -119,7 +119,11 @@ def expression(
     `use_signature=False`.
     """
     kwargs["use_signature"] = kwargs.get("use_signature", False)
+
     if fn is not None:
-        return function(fn, **kwargs)
-    else:
-        return function(**kwargs)
+        return ipython_wrappers.LatexifiedFunction(fn, **kwargs)
+
+    def wrapper(f):
+        return ipython_wrappers.LatexifiedFunction(f, **kwargs)
+
+    return wrapper

--- a/src/latexify/generate_latex.py
+++ b/src/latexify/generate_latex.py
@@ -15,7 +15,6 @@ class Style(enum.Enum):
     """The style of the generated LaTeX."""
 
     ALGORITHMIC = "algorithmic"
-    EXPRESSION = "expression"
     FUNCTION = "function"
     IPYTHON_ALGORITHMIC = "ipython-algorithmic"
 
@@ -67,11 +66,11 @@ def get_latex(
     elif style == Style.IPYTHON_ALGORITHMIC:
         # TODO(ZibingZhang): implement algorithmic codegen for ipython
         raise exceptions.LatexifyNotSupportedError
-    else:
-        if style == Style.EXPRESSION:
-            kwargs["use_signature"] = kwargs.get("use_signature", False)
+    elif style == Style.FUNCTION:
         return codegen.FunctionCodegen(
             use_math_symbols=merged_config.use_math_symbols,
             use_signature=merged_config.use_signature,
             use_set_symbols=merged_config.use_set_symbols,
         ).visit(tree)
+
+    raise ValueError(f"Unrecognized style: {style}")


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Removes `Style.EXPRESSION`.

CC @ZibingZhang 

# Details

This style only affects against a specific config without changing the overall algorithm of codegen. It is better to be removed at this moment for simplicity.

# References

NA

# Blocked by

NA
