### PR TITLE
Basic NumPy Transpose Use Cases

### DIFF
--- a/src/latexify/codegen/expression_codegen.py
+++ b/src/latexify/codegen/expression_codegen.py
@@ -218,6 +218,27 @@ class ExpressionCodegen(ast.NodeVisitor):
 
         return rf"\mathbf{{I}}_{{{ndims}}}"
 
+    def _generate_transpose(self, node: ast.Call) -> str | None:
+        """Generates LaTeX for numpy.transpose.
+        Args:
+            node: ast.Call node containing the appropriate method invocation.
+        Returns:
+            Generated LaTeX, or None if the node has unsupported syntax.
+        Raises:
+            LatexifyError: Unsupported argument type given.
+        """
+        name = ast_utils.extract_function_name_or_none(node)
+        assert name == "transpose"
+
+        if len(node.args) != 1:
+            return None
+
+        func_arg = node.args[0]
+        if isinstance(func_arg, ast.Name):
+            return rf"\mathbf{{{func_arg.id}}}^\intercal"
+        else:
+            return None
+
     def visit_Call(self, node: ast.Call) -> str:
         """Visit a Call node."""
         func_name = ast_utils.extract_function_name_or_none(node)
@@ -232,6 +253,8 @@ class ExpressionCodegen(ast.NodeVisitor):
             special_latex = self._generate_zeros(node)
         elif func_name == "identity":
             special_latex = self._generate_identity(node)
+        elif func_name == "transpose":
+            special_latex = self._generate_transpose(node)
         else:
             special_latex = None
 

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -970,3 +970,24 @@ def test_identity(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("transpose(A)", r"\mathbf{A}^\intercal"),
+        ("transpose(b)", r"\mathbf{b}^\intercal"),
+        # Unsupported
+        ("transpose()", r"\mathrm{transpose} \mathopen{}\left( \mathclose{}\right)"),
+        ("transpose(2)", r"\mathrm{transpose} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "transpose(a, (1, 0))",
+            r"\mathrm{transpose} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ],
+)
+def test_transpose(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex

--- a/src/latexify/frontend.py
+++ b/src/latexify/frontend.py
@@ -24,9 +24,10 @@ def algorithmic(
 
 def algorithmic(
     fn: Callable[..., Any] | None = None, **kwargs: Any
-) -> ipython_wrappers.LatexifiedAlgorithm | Callable[
-    [Callable[..., Any]], ipython_wrappers.LatexifiedAlgorithm
-]:
+) -> (
+    ipython_wrappers.LatexifiedAlgorithm
+    | Callable[[Callable[..., Any]], ipython_wrappers.LatexifiedAlgorithm]
+):
     """Attach LaTeX pretty-printing to the given function.
 
     This function works with or without specifying the target function as the
@@ -67,9 +68,10 @@ def function(
 
 def function(
     fn: Callable[..., Any] | None = None, **kwargs: Any
-) -> ipython_wrappers.LatexifiedFunction | Callable[
-    [Callable[..., Any]], ipython_wrappers.LatexifiedFunction
-]:
+) -> (
+    ipython_wrappers.LatexifiedFunction
+    | Callable[[Callable[..., Any]], ipython_wrappers.LatexifiedFunction]
+):
     """Attach LaTeX pretty-printing to the given function.
 
     This function works with or without specifying the target function as the positional
@@ -110,9 +112,10 @@ def expression(
 
 def expression(
     fn: Callable[..., Any] | None = None, **kwargs: Any
-) -> ipython_wrappers.LatexifiedFunction | Callable[
-    [Callable[..., Any]], ipython_wrappers.LatexifiedFunction
-]:
+) -> (
+    ipython_wrappers.LatexifiedFunction
+    | Callable[[Callable[..., Any]], ipython_wrappers.LatexifiedFunction]
+):
     """Attach LaTeX pretty-printing to the given function.
 
     This function is a shortcut for `latexify.function` with the default parameter


### PR DESCRIPTION
# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

Added very basic NumPy transpose functionality. This PR supports the transpose of variables (ie. transpose(A), transpose(b), etc.).

This PR does not support non-variables (ie. numbers) or axes arguments for transpose. I would like to extend this eventually to recursively call latexify on other types of parseable input such as transpose([1, 2, 3]) or transpose(zeros(1)).

# Details

<!-- EDIT HERE IF ANY:
Write a detailed description of this change.
This section should include all changed introduced by this pull request.
It is also recommended to describe the backgrounds, approaches, and any other
information related to the pull request.
-->

Added changes to [expression_codegen.py](https://github.com/google/latexify_py/blob/main/src/latexify/codegen/expression_codegen.py) and followed the same style as the NumPy identity implementation.

Added tests to [expression_codegen_test.py](https://github.com/google/latexify_py/blob/main/src/latexify/codegen/expression_codegen_test.py).

Also black reformatted [frontend.py](https://github.com/google/latexify_py/blob/main/src/latexify/frontend.py). 

I wanted to make a small first PR to learn about the library and also confirm the direction for implementing more NumPy functions. See relevant issues below.

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->
#149 
#165 

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
N/A