### PR TITLE
Added remaining Numpy NDArray single function expressions

### DIFF
--- a/src/latexify/codegen/expression_codegen.py
+++ b/src/latexify/codegen/expression_codegen.py
@@ -6,11 +6,7 @@ import ast
 import re
 
 from latexify import analyzers, ast_utils, exceptions
-from latexify.codegen import (
-    codegen_utils,
-    expression_rules,
-    identifier_converter,
-)
+from latexify.codegen import codegen_utils, expression_rules, identifier_converter
 
 
 class ExpressionCodegen(ast.NodeVisitor):
@@ -333,10 +329,12 @@ class ExpressionCodegen(ast.NodeVisitor):
 
         func_arg = node.args[0]
         if isinstance(func_arg, ast.Name):
-            return rf"\mathrm{{{name.upper()}}} \left( \mathbf{{{func_arg.id}}} \right)"
-        elif isinstance(func_arg, ast.List):
-            return rf"\mathrm{{{name.upper()}}} \left( {self._generate_matrix(node)} \right)"
+            func_arg_str = rf"\mathbf{{{func_arg.id}}}"
+            return rf"\mathrm{{{name.upper()}}} \left( {func_arg_str} \right)"
 
+        elif isinstance(func_arg, ast.List):
+            matrix_str = self._generate_matrix(node)
+            return rf"\mathrm{{{name.upper()}}} \left( {matrix_str} \right)"
         return None
 
     def _generate_inverses(self, node: ast.Call) -> str | None:

--- a/src/latexify/codegen/expression_codegen.py
+++ b/src/latexify/codegen/expression_codegen.py
@@ -6,7 +6,11 @@ import ast
 import re
 
 from latexify import analyzers, ast_utils, exceptions
-from latexify.codegen import codegen_utils, expression_rules, identifier_converter
+from latexify.codegen import (
+    codegen_utils,
+    expression_rules,
+    identifier_converter,
+)
 
 
 class ExpressionCodegen(ast.NodeVisitor):
@@ -23,8 +27,8 @@ class ExpressionCodegen(ast.NodeVisitor):
         """Initializer.
 
         Args:
-            use_math_symbols: Whether to convert identifiers with a math symbol surface
-                (e.g., "alpha") to the LaTeX symbol (e.g., "\\alpha").
+            use_math_symbols: Whether to convert identifiers with a math symbol
+                surface (e.g., "alpha") to the LaTeX symbol (e.g., "\\alpha").
             use_set_symbols: Whether to use set symbols or not.
         """
         self._identifier_converter = identifier_converter.IdentifierConverter(
@@ -260,7 +264,7 @@ class ExpressionCodegen(ast.NodeVisitor):
             return rf"\det \left( \mathbf{{{func_arg.id}}} \right)"
         elif isinstance(func_arg, ast.List):
             return rf"\det \left( {self._generate_matrix(node)} \right)"
-        
+
         return None
 
     def _generate_matrix_rank(self, node: ast.Call) -> str | None:
@@ -283,7 +287,7 @@ class ExpressionCodegen(ast.NodeVisitor):
             return rf"\mathrm{{rank}} \left( \mathbf{{{func_arg.id}}} \right)"
         elif isinstance(func_arg, ast.List):
             return rf"\mathrm{{rank}} \left( {self._generate_matrix(node)} \right)"
-        
+
         return None
 
     def _generate_matrix_power(self, node: ast.Call) -> str | None:
@@ -307,7 +311,9 @@ class ExpressionCodegen(ast.NodeVisitor):
             if isinstance(func_arg, ast.Name):
                 return rf"\mathbf{{{func_arg.id}}}^{{{power_arg.n}}}"
             elif isinstance(func_arg, ast.List):
-                return self._generate_matrix(node) + rf"^{{{power_arg.n}}}"
+                matrix = self._generate_matrix(node)
+                if matrix is not None:
+                    return rf"{matrix}^{{{power_arg.n}}}"
         return None
 
     def _generate_qr_and_svd(self, node: ast.Call) -> str | None:
@@ -332,7 +338,7 @@ class ExpressionCodegen(ast.NodeVisitor):
             return rf"\mathrm{{{name.upper()}}} \left( {self._generate_matrix(node)} \right)"
 
         return None
-    
+
     def _generate_inverses(self, node: ast.Call) -> str | None:
         """Generates LaTeX for numpy.linalg.inv.
         Args:
@@ -350,11 +356,11 @@ class ExpressionCodegen(ast.NodeVisitor):
 
         func_arg = node.args[0]
         if isinstance(func_arg, ast.Name):
-            if (name == "inv"):
+            if name == "inv":
                 return rf"\mathbf{{{func_arg.id}}}^{{-1}}"
             return rf"\mathbf{{{func_arg.id}}}^{{+}}"
         elif isinstance(func_arg, ast.List):
-            if (name == "inv"):
+            if name == "inv":
                 return rf"{self._generate_matrix(node)}^{{-1}}"
             return rf"{self._generate_matrix(node)}^{{+}}"
         return None

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -1004,7 +1004,8 @@ def test_transpose(code: str, latex: str) -> None:
         ),
         (
             "det([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \right)",
         ),
         # Unsupported
         ("det()", r"\mathrm{det} \mathopen{}\left( \mathclose{}\right)"),
@@ -1029,11 +1030,13 @@ def test_determinant(code: str, latex: str) -> None:
         ("matrix_rank(b)", r"\mathrm{rank} \left( \mathbf{b} \right)"),
         (
             "matrix_rank([[1, 2], [3, 4]])",
-            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\"
+            r" 3 & 4 \end{bmatrix} \right)",
         ),
         (
             "matrix_rank([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \right)",
         ),
         # Unsupported
         (
@@ -1104,7 +1107,8 @@ def test_matrix_power(code: str, latex: str) -> None:
         ),
         (
             "QR([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \right)",
         ),
         # Unsupported
         ("QR()", r"\mathrm{QR} \mathopen{}\left( \mathclose{}\right)"),
@@ -1123,7 +1127,8 @@ def test_matrix_power(code: str, latex: str) -> None:
         ),
         (
             "SVD([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \right)",
         ),
         # Unsupported
         ("SVD()", r"\mathrm{SVD} \mathopen{}\left( \mathclose{}\right)"),

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -992,6 +992,144 @@ def test_transpose(code: str, latex: str) -> None:
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
 
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("det(A)", r"\det \left( \mathbf{A} \right)"),
+        ("det(b)", r"\det \left( \mathbf{b} \right)"),
+        ("det([[1, 2], [3, 4]])", r"\det \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
+        ("det([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        # Unsupported
+        ("det()", r"\mathrm{det} \mathopen{}\left( \mathclose{}\right)"),
+        ("det(2)", r"\mathrm{det} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "det(a, (1, 0))",
+            r"\mathrm{det} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ]
+)
+def test_determinant(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("matrix_rank(A)", r"\mathrm{rank} \left( \mathbf{A} \right)"),
+        ("matrix_rank(b)", r"\mathrm{rank} \left( \mathbf{b} \right)"),
+        ("matrix_rank([[1, 2], [3, 4]])", r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
+        ("matrix_rank([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        # Unsupported
+        ("matrix_rank()", r"\mathrm{matrix\_rank} \mathopen{}\left( \mathclose{}\right)"),
+        ("matrix_rank(2)", r"\mathrm{matrix\_rank} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "matrix_rank(a, (1, 0))",
+            r"\mathrm{matrix\_rank} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ]
+)
+def test_matrix_rank(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("matrix_power(A, 2)", r"\mathbf{A}^{2}"),
+        ("matrix_power(b, 2)", r"\mathbf{b}^{2}"),
+        ("matrix_power([[1, 2], [3, 4]], 2)", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{2}"),
+        ("matrix_power([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 42)", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{42}"),
+        # Unsupported
+        ("matrix_power()", r"\mathrm{matrix\_power} \mathopen{}\left( \mathclose{}\right)"),
+        ("matrix_power(2)", r"\mathrm{matrix\_power} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "matrix_power(a, (1, 0))",
+            r"\mathrm{matrix\_power} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ]
+)
+def test_matrix_power(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        # Test QR
+        ("QR(A)", r"\mathrm{QR} \left( \mathbf{A} \right)"),
+        ("QR(b)", r"\mathrm{QR} \left( \mathbf{b} \right)"),
+        ("QR([[1, 2], [3, 4]])", r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
+        ("QR([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        # Unsupported
+        ("QR()", r"\mathrm{QR} \mathopen{}\left( \mathclose{}\right)"),
+        ("QR(2)", r"\mathrm{QR} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "QR(a, (1, 0))",
+            r"\mathrm{QR} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+        # Test SVD
+        ("SVD(A)", r"\mathrm{SVD} \left( \mathbf{A} \right)"),
+        ("SVD(b)", r"\mathrm{SVD} \left( \mathbf{b} \right)"),
+        ("SVD([[1, 2], [3, 4]])", r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
+        ("SVD([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        # Unsupported
+        ("SVD()", r"\mathrm{SVD} \mathopen{}\left( \mathclose{}\right)"),
+        ("SVD(2)", r"\mathrm{SVD} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "SVD(a, (1, 0))",
+            r"\mathrm{SVD} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ]
+)
+def test_qr_and_svd(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+# tests for inv and pinv
+@pytest.mark.parametrize(
+    "code,latex",
+    [
+        # Test inv
+        ("inv(A)", r"\mathbf{A}^{-1}"),
+        ("inv(b)", r"\mathbf{b}^{-1}"),
+        ("inv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{-1}"),
+        ("inv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{-1}"),
+        # Unsupported
+        ("inv()", r"\mathrm{inv} \mathopen{}\left( \mathclose{}\right)"),
+        ("inv(2)", r"\mathrm{inv} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "inv(a, (1, 0))",
+            r"\mathrm{inv} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+        # Test pinv
+        ("pinv(A)", r"\mathbf{A}^{+}"),
+        ("pinv(b)", r"\mathbf{b}^{+}"),
+        ("pinv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{+}"),
+        ("pinv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{+}"),
+        # Unsupported
+        ("pinv()", r"\mathrm{pinv} \mathopen{}\left( \mathclose{}\right)"),
+        ("pinv(2)", r"\mathrm{pinv} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "pinv(a, (1, 0))",
+            r"\mathrm{pinv} \mathopen{}\left( a, "
+            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
+        ),
+    ]
+)
+def test_inv_and_pinv(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
 
 # Check list for #89.
 # https://github.com/google/latexify_py/issues/89#issuecomment-1344967636

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -996,16 +996,17 @@ def test_transpose(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("det(A)", r"\det \left( \mathbf{A} \right)"),
-        ("det(b)", r"\det \left( \mathbf{b} \right)"),
+        ("det(A)", r"\det \mathopen{}\left( \mathbf{A} \mathclose{}\right)"),
+        ("det(b)", r"\det \mathopen{}\left( \mathbf{b} \mathclose{}\right)"),
         (
             "det([[1, 2], [3, 4]])",
-            r"\det \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+            r"\det \mathopen{}\left( \begin{bmatrix} 1 & 2 \\"
+            r" 3 & 4 \end{bmatrix} \mathclose{}\right)",
         ),
         (
             "det([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
-            r" 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\det \mathopen{}\left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \mathclose{}\right)",
         ),
         # Unsupported
         ("det()", r"\mathrm{det} \mathopen{}\left( \mathclose{}\right)"),
@@ -1026,17 +1027,23 @@ def test_determinant(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        ("matrix_rank(A)", r"\mathrm{rank} \left( \mathbf{A} \right)"),
-        ("matrix_rank(b)", r"\mathrm{rank} \left( \mathbf{b} \right)"),
+        (
+            "matrix_rank(A)",
+            r"\mathrm{rank} \mathopen{}\left( \mathbf{A} \mathclose{}\right)",
+        ),
+        (
+            "matrix_rank(b)",
+            r"\mathrm{rank} \mathopen{}\left( \mathbf{b} \mathclose{}\right)",
+        ),
         (
             "matrix_rank([[1, 2], [3, 4]])",
-            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\"
-            r" 3 & 4 \end{bmatrix} \right)",
+            r"\mathrm{rank} \mathopen{}\left( \begin{bmatrix} 1 & 2 \\"
+            r" 3 & 4 \end{bmatrix} \mathclose{}\right)",
         ),
         (
             "matrix_rank([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
-            r" 7 & 8 & 9 \end{bmatrix} \right)",
+            r"\mathrm{rank} \mathopen{}\left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
+            r" 7 & 8 & 9 \end{bmatrix} \mathclose{}\right)",
         ),
         # Unsupported
         (
@@ -1098,59 +1105,6 @@ def test_matrix_power(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "code,latex",
     [
-        # Test QR
-        ("QR(A)", r"\mathrm{QR} \left( \mathbf{A} \right)"),
-        ("QR(b)", r"\mathrm{QR} \left( \mathbf{b} \right)"),
-        (
-            "QR([[1, 2], [3, 4]])",
-            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
-        ),
-        (
-            "QR([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
-            r" 7 & 8 & 9 \end{bmatrix} \right)",
-        ),
-        # Unsupported
-        ("QR()", r"\mathrm{QR} \mathopen{}\left( \mathclose{}\right)"),
-        ("QR(2)", r"\mathrm{QR} \mathopen{}\left( 2 \mathclose{}\right)"),
-        (
-            "QR(a, (1, 0))",
-            r"\mathrm{QR} \mathopen{}\left( a, "
-            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
-        ),
-        # Test SVD
-        ("SVD(A)", r"\mathrm{SVD} \left( \mathbf{A} \right)"),
-        ("SVD(b)", r"\mathrm{SVD} \left( \mathbf{b} \right)"),
-        (
-            "SVD([[1, 2], [3, 4]])",
-            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
-        ),
-        (
-            "SVD([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
-            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\"
-            r" 7 & 8 & 9 \end{bmatrix} \right)",
-        ),
-        # Unsupported
-        ("SVD()", r"\mathrm{SVD} \mathopen{}\left( \mathclose{}\right)"),
-        ("SVD(2)", r"\mathrm{SVD} \mathopen{}\left( 2 \mathclose{}\right)"),
-        (
-            "SVD(a, (1, 0))",
-            r"\mathrm{SVD} \mathopen{}\left( a, "
-            r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
-        ),
-    ],
-)
-def test_qr_and_svd(code: str, latex: str) -> None:
-    tree = ast_utils.parse_expr(code)
-    assert isinstance(tree, ast.Call)
-    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
-
-
-# tests for inv and pinv
-@pytest.mark.parametrize(
-    "code,latex",
-    [
-        # Test inv
         ("inv(A)", r"\mathbf{A}^{-1}"),
         ("inv(b)", r"\mathbf{b}^{-1}"),
         ("inv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{-1}"),
@@ -1166,7 +1120,17 @@ def test_qr_and_svd(code: str, latex: str) -> None:
             r"\mathrm{inv} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-        # Test pinv
+    ],
+)
+def test_inv(code: str, latex: str) -> None:
+    tree = ast_utils.parse_expr(code)
+    assert isinstance(tree, ast.Call)
+    assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
+
+@pytest.mark.parametrize(
+    "code,latex",
+    [
         ("pinv(A)", r"\mathbf{A}^{+}"),
         ("pinv(b)", r"\mathbf{b}^{+}"),
         ("pinv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{+}"),
@@ -1184,7 +1148,7 @@ def test_qr_and_svd(code: str, latex: str) -> None:
         ),
     ],
 )
-def test_inv_and_pinv(code: str, latex: str) -> None:
+def test_pinv(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -992,13 +992,20 @@ def test_transpose(code: str, latex: str) -> None:
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
 
+
 @pytest.mark.parametrize(
     "code,latex",
     [
         ("det(A)", r"\det \left( \mathbf{A} \right)"),
         ("det(b)", r"\det \left( \mathbf{b} \right)"),
-        ("det([[1, 2], [3, 4]])", r"\det \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
-        ("det([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        (
+            "det([[1, 2], [3, 4]])",
+            r"\det \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+        ),
+        (
+            "det([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\det \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+        ),
         # Unsupported
         ("det()", r"\mathrm{det} \mathopen{}\left( \mathclose{}\right)"),
         ("det(2)", r"\mathrm{det} \mathopen{}\left( 2 \mathclose{}\right)"),
@@ -1007,56 +1014,83 @@ def test_transpose(code: str, latex: str) -> None:
             r"\mathrm{det} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-    ]
+    ],
 )
 def test_determinant(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
 
+
 @pytest.mark.parametrize(
     "code,latex",
     [
         ("matrix_rank(A)", r"\mathrm{rank} \left( \mathbf{A} \right)"),
         ("matrix_rank(b)", r"\mathrm{rank} \left( \mathbf{b} \right)"),
-        ("matrix_rank([[1, 2], [3, 4]])", r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
-        ("matrix_rank([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        (
+            "matrix_rank([[1, 2], [3, 4]])",
+            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+        ),
+        (
+            "matrix_rank([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\mathrm{rank} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+        ),
         # Unsupported
-        ("matrix_rank()", r"\mathrm{matrix\_rank} \mathopen{}\left( \mathclose{}\right)"),
-        ("matrix_rank(2)", r"\mathrm{matrix\_rank} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "matrix_rank()",
+            r"\mathrm{matrix\_rank} \mathopen{}\left( \mathclose{}\right)",
+        ),
+        (
+            "matrix_rank(2)",
+            r"\mathrm{matrix\_rank} \mathopen{}\left( 2 \mathclose{}\right)",
+        ),
         (
             "matrix_rank(a, (1, 0))",
             r"\mathrm{matrix\_rank} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-    ]
+    ],
 )
 def test_matrix_rank(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
 
+
 @pytest.mark.parametrize(
     "code,latex",
     [
         ("matrix_power(A, 2)", r"\mathbf{A}^{2}"),
         ("matrix_power(b, 2)", r"\mathbf{b}^{2}"),
-        ("matrix_power([[1, 2], [3, 4]], 2)", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{2}"),
-        ("matrix_power([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 42)", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{42}"),
+        (
+            "matrix_power([[1, 2], [3, 4]], 2)",
+            r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{2}",
+        ),
+        (
+            "matrix_power([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 42)",
+            r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{42}",
+        ),
         # Unsupported
-        ("matrix_power()", r"\mathrm{matrix\_power} \mathopen{}\left( \mathclose{}\right)"),
-        ("matrix_power(2)", r"\mathrm{matrix\_power} \mathopen{}\left( 2 \mathclose{}\right)"),
+        (
+            "matrix_power()",
+            r"\mathrm{matrix\_power} \mathopen{}\left( \mathclose{}\right)",
+        ),
+        (
+            "matrix_power(2)",
+            r"\mathrm{matrix\_power} \mathopen{}\left( 2 \mathclose{}\right)",
+        ),
         (
             "matrix_power(a, (1, 0))",
             r"\mathrm{matrix\_power} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-    ]
+    ],
 )
 def test_matrix_power(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
 
 @pytest.mark.parametrize(
     "code,latex",
@@ -1064,8 +1098,14 @@ def test_matrix_power(code: str, latex: str) -> None:
         # Test QR
         ("QR(A)", r"\mathrm{QR} \left( \mathbf{A} \right)"),
         ("QR(b)", r"\mathrm{QR} \left( \mathbf{b} \right)"),
-        ("QR([[1, 2], [3, 4]])", r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
-        ("QR([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        (
+            "QR([[1, 2], [3, 4]])",
+            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+        ),
+        (
+            "QR([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\mathrm{QR} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+        ),
         # Unsupported
         ("QR()", r"\mathrm{QR} \mathopen{}\left( \mathclose{}\right)"),
         ("QR(2)", r"\mathrm{QR} \mathopen{}\left( 2 \mathclose{}\right)"),
@@ -1077,8 +1117,14 @@ def test_matrix_power(code: str, latex: str) -> None:
         # Test SVD
         ("SVD(A)", r"\mathrm{SVD} \left( \mathbf{A} \right)"),
         ("SVD(b)", r"\mathrm{SVD} \left( \mathbf{b} \right)"),
-        ("SVD([[1, 2], [3, 4]])", r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)"),
-        ("SVD([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)"),
+        (
+            "SVD([[1, 2], [3, 4]])",
+            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} \right)",
+        ),
+        (
+            "SVD([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\mathrm{SVD} \left( \begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix} \right)",
+        ),
         # Unsupported
         ("SVD()", r"\mathrm{SVD} \mathopen{}\left( \mathclose{}\right)"),
         ("SVD(2)", r"\mathrm{SVD} \mathopen{}\left( 2 \mathclose{}\right)"),
@@ -1087,12 +1133,13 @@ def test_matrix_power(code: str, latex: str) -> None:
             r"\mathrm{SVD} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-    ]
+    ],
 )
 def test_qr_and_svd(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
 
 # tests for inv and pinv
 @pytest.mark.parametrize(
@@ -1102,7 +1149,10 @@ def test_qr_and_svd(code: str, latex: str) -> None:
         ("inv(A)", r"\mathbf{A}^{-1}"),
         ("inv(b)", r"\mathbf{b}^{-1}"),
         ("inv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{-1}"),
-        ("inv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{-1}"),
+        (
+            "inv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{-1}",
+        ),
         # Unsupported
         ("inv()", r"\mathrm{inv} \mathopen{}\left( \mathclose{}\right)"),
         ("inv(2)", r"\mathrm{inv} \mathopen{}\left( 2 \mathclose{}\right)"),
@@ -1115,7 +1165,10 @@ def test_qr_and_svd(code: str, latex: str) -> None:
         ("pinv(A)", r"\mathbf{A}^{+}"),
         ("pinv(b)", r"\mathbf{b}^{+}"),
         ("pinv([[1, 2], [3, 4]])", r"\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}^{+}"),
-        ("pinv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])", r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{+}"),
+        (
+            "pinv([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            r"\begin{bmatrix} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{bmatrix}^{+}",
+        ),
         # Unsupported
         ("pinv()", r"\mathrm{pinv} \mathopen{}\left( \mathclose{}\right)"),
         ("pinv(2)", r"\mathrm{pinv} \mathopen{}\left( 2 \mathclose{}\right)"),
@@ -1124,12 +1177,13 @@ def test_qr_and_svd(code: str, latex: str) -> None:
             r"\mathrm{pinv} \mathopen{}\left( a, "
             r"\mathopen{}\left( 1, 0 \mathclose{}\right) \mathclose{}\right)",
         ),
-    ]
+    ],
 )
 def test_inv_and_pinv(code: str, latex: str) -> None:
     tree = ast_utils.parse_expr(code)
     assert isinstance(tree, ast.Call)
     assert expression_codegen.ExpressionCodegen().visit(tree) == latex
+
 
 # Check list for #89.
 # https://github.com/google/latexify_py/issues/89#issuecomment-1344967636


### PR DESCRIPTION
# Overview

This pull request expands support for several NumPy linear algebra functions involving a single operand (as mentioned in #149), including `numpy.linalg.{matrix_power, qr, svd, det, matrix_rank, inv, pinv}`. It introduces support for applying these functions to both variables and NDArrays, improving the versatility of the codebase.

# Details

Key changes in this PR:

- Added new functions and modified existing code in [expression_codegen.py](https://github.com/google/latexify_py/blob/main/src/latexify/codegen/expression_codegen.py)  to support the specified Numpy linear algebra functions.
- Included comprehensive test cases in [expression_codegen_test.py](https://github.com/google/latexify_py/blob/main/src/latexify/codegen/expression_codegen_test.py) to validate the correctness of the new implementations.
- Followed a coding style consistent with the NumPy `transpose` implementation.

# References

#149 

# Blocked by

N/A
