### PR TITLE
Fix bug on log10 representation

### DIFF
--- a/src/latexify/codegen/expression_rules.py
+++ b/src/latexify/codegen/expression_rules.py
@@ -252,7 +252,7 @@ BUILTIN_FUNCS: dict[str, FunctionRule] = {
     "fsum": FunctionRule(r"\sum", is_unary=True),
     "gamma": FunctionRule(r"\Gamma"),
     "log": FunctionRule(r"\log", is_unary=True),
-    "log10": FunctionRule(r"\log_10", is_unary=True),
+    "log10": FunctionRule(r"\log_{10}", is_unary=True),
     "log2": FunctionRule(r"\log_2", is_unary=True),
     "prod": FunctionRule(r"\prod", is_unary=True),
     "sec": FunctionRule(r"\sec", is_unary=True),


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Fix bug on `log10`: $\log_10$ -> $\log_{10}$ .
The bug was reported by a colleague.

# Details

SSIA

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
