### PR TITLE
Support pass/break/continue in algorithmic codegens

### DIFF
--- a/src/latexify/codegen/algorithmic_codegen.py
+++ b/src/latexify/codegen/algorithmic_codegen.py
@@ -150,6 +150,18 @@ class AlgorithmicCodegen(ast.NodeVisitor):
             + self._add_indent(r"\EndWhile")
         )
 
+    def visit_Pass(self, node: ast.Pass) -> str:
+        """Visit a Pass node."""
+        return self._add_indent(r"\State $\mathbf{pass}$")
+
+    def visit_Break(self, node: ast.Break) -> str:
+        """Visit a Break node."""
+        return self._add_indent(r"\State $\mathbf{break}$")
+
+    def visit_Continue(self, node: ast.Continue) -> str:
+        """Visit a Continue node."""
+        return self._add_indent(r"\State $\mathbf{continue}$")
+
     @contextlib.contextmanager
     def _increment_level(self) -> Generator[None, None, None]:
         """Context manager controlling indent level."""
@@ -302,6 +314,18 @@ class IPythonAlgorithmicCodegen(ast.NodeVisitor):
             + f"{cond_latex}{self._LINE_BREAK}{body_latex}{self._LINE_BREAK}"
             + self._add_indent(r"\mathbf{end \ while}")
         )
+
+    def visit_Pass(self, node: ast.Pass) -> str:
+        """Visit a Pass node."""
+        return self._add_indent(r"\mathbf{pass}")
+
+    def visit_Break(self, node: ast.Break) -> str:
+        """Visit a Break node."""
+        return self._add_indent(r"\mathbf{break}")
+
+    def visit_Continue(self, node: ast.Continue) -> str:
+        """Visit a Continue node."""
+        return self._add_indent(r"\mathbf{continue}")
 
     @contextlib.contextmanager
     def _increment_level(self) -> Generator[None, None, None]:

--- a/src/latexify/codegen/algorithmic_codegen_test.py
+++ b/src/latexify/codegen/algorithmic_codegen_test.py
@@ -189,6 +189,33 @@ def test_visit_while_with_else() -> None:
         algorithmic_codegen.AlgorithmicCodegen().visit(node)
 
 
+def test_visit_pass() -> None:
+    node = ast.parse("pass").body[0]
+    assert isinstance(node, ast.Pass)
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == r"\State $\mathbf{pass}$"
+    )
+
+
+def test_visit_break() -> None:
+    node = ast.parse("break").body[0]
+    assert isinstance(node, ast.Break)
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == r"\State $\mathbf{break}$"
+    )
+
+
+def test_visit_continue() -> None:
+    node = ast.parse("continue").body[0]
+    assert isinstance(node, ast.Continue)
+    assert (
+        algorithmic_codegen.AlgorithmicCodegen().visit(node)
+        == r"\State $\mathbf{continue}$"
+    )
+
+
 @pytest.mark.parametrize(
     "code,latex",
     [
@@ -342,3 +369,28 @@ def test_visit_while_with_else_ipython() -> None:
         match="^While statement with the else clause is not supported$",
     ):
         algorithmic_codegen.IPythonAlgorithmicCodegen().visit(node)
+
+
+def test_visit_pass_ipython() -> None:
+    node = ast.parse("pass").body[0]
+    assert isinstance(node, ast.Pass)
+    assert (
+        algorithmic_codegen.IPythonAlgorithmicCodegen().visit(node) == r"\mathbf{pass}"
+    )
+
+
+def test_visit_break_ipython() -> None:
+    node = ast.parse("break").body[0]
+    assert isinstance(node, ast.Break)
+    assert (
+        algorithmic_codegen.IPythonAlgorithmicCodegen().visit(node) == r"\mathbf{break}"
+    )
+
+
+def test_visit_continue_ipython() -> None:
+    node = ast.parse("continue").body[0]
+    assert isinstance(node, ast.Continue)
+    assert (
+        algorithmic_codegen.IPythonAlgorithmicCodegen().visit(node)
+        == r"\mathbf{continue}"
+    )


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR adds support for `pass`, `break`, `continue` syntaxes to `AlgorithmicCodegen` and `IPythonAlgorithmicCodegen`

# Details

The new rule just returns `\mathbf{keyword}` where keyword are either the above one.

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
