### PR TITLE
Fix behavior of sum/prod with no arguments

### DIFF
--- a/src/latexify/codegen/expression_codegen.py
+++ b/src/latexify/codegen/expression_codegen.py
@@ -105,7 +105,7 @@ class ExpressionCodegen(ast.NodeVisitor):
         Returns:
             Generated LaTeX, or None if the node has unsupported syntax.
         """
-        if not isinstance(node.args[0], ast.GeneratorExp):
+        if not node.args or not isinstance(node.args[0], ast.GeneratorExp):
             return None
 
         name = ast_utils.extract_function_name_or_none(node)

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -221,6 +221,8 @@ def test_visit_call(code: str, latex: str) -> None:
 @pytest.mark.parametrize(
     "src_suffix,dest_suffix",
     [
+        # No arguments
+        ("()", r" \mathopen{}\left( \mathclose{}\right)"),
         # No comprehension
         ("(x)", r" x"),
         (


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR fixes compile errors around `sum` and `prod` invocation with no arguments.

# Details

Added an additional check for the empty argument list.

# References

<!-- EDIT HERE IF ANY:
Put the list of issue IDs or links to external discussions related to this pull request.
-->

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
