### PR TITLE
Fix wrapping around power operators.

### DIFF
--- a/src/latexify/codegen/expression_codegen.py
+++ b/src/latexify/codegen/expression_codegen.py
@@ -408,16 +408,22 @@ class ExpressionCodegen(ast.NodeVisitor):
 
         if rule.is_unary and len(node.args) == 1:
             # Unary function. Applies the same wrapping policy with the unary operators.
+            precedence = expression_rules.get_precedence(node)
+            arg = node.args[0]
             # NOTE(odashi):
             # Factorial "x!" is treated as a special case: it requires both inner/outer
             # parentheses for correct interpretation.
-            precedence = expression_rules.get_precedence(node)
-            arg = node.args[0]
-            force_wrap = isinstance(arg, ast.Call) and (
+            force_wrap_factorial = isinstance(arg, ast.Call) and (
                 func_name == "factorial"
                 or ast_utils.extract_function_name_or_none(arg) == "factorial"
             )
-            arg_latex = self._wrap_operand(arg, precedence, force_wrap)
+            # Note(odashi):
+            # Wrapping is also required if the argument is pow.
+            # https://github.com/google/latexify_py/issues/189
+            force_wrap_pow = isinstance(arg, ast.BinOp) and isinstance(arg.op, ast.Pow)
+            arg_latex = self._wrap_operand(
+                arg, precedence, force_wrap_factorial or force_wrap_pow
+            )
             elements = [rule.left, arg_latex, rule.right]
         else:
             arg_latex = ", ".join(self.visit(arg) for arg in node.args)
@@ -490,7 +496,7 @@ class ExpressionCodegen(ast.NodeVisitor):
         latex = self.visit(child)
         child_prec = expression_rules.get_precedence(child)
 
-        if child_prec < parent_prec or force_wrap and child_prec == parent_prec:
+        if force_wrap or child_prec < parent_prec:
             return rf"\mathopen{{}}\left( {latex} \mathclose{{}}\right)"
 
         return latex

--- a/src/latexify/codegen/expression_codegen_test.py
+++ b/src/latexify/codegen/expression_codegen_test.py
@@ -219,6 +219,25 @@ def test_visit_call(code: str, latex: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "code,latex",
+    [
+        ("log(x)**2", r"\mathopen{}\left( \log x \mathclose{}\right)^{2}"),
+        ("log(x**2)", r"\log \mathopen{}\left( x^{2} \mathclose{}\right)"),
+        (
+            "log(x**2)**3",
+            r"\mathopen{}\left("
+            r" \log \mathopen{}\left( x^{2} \mathclose{}\right)"
+            r" \mathclose{}\right)^{3}",
+        ),
+    ],
+)
+def test_visit_call_with_pow(code: str, latex: str) -> None:
+    node = ast_utils.parse_expr(code)
+    assert isinstance(node, (ast.Call, ast.BinOp))
+    assert expression_codegen.ExpressionCodegen().visit(node) == latex
+
+
+@pytest.mark.parametrize(
     "src_suffix,dest_suffix",
     [
         # No arguments


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR changes the wrapping behavior around function calls with pow.

# Details

Due to its visual ambiguity, the power operator should be always wrapped by brackets if it appears in the unary function.

Before:
<img width="191" alt="a" src="https://github.com/google/latexify_py/assets/1023695/e60ad7ab-5c46-460c-ae68-54daf59afdf4">

After:
<img width="213" alt="無題" src="https://github.com/google/latexify_py/assets/1023695/a5d1b43f-bb2e-4fe4-97a5-23168133478a">

# References

- Fix #189 

# Blocked by

<!-- EDIT HERE IF ANY:
Put the list of pull request IDs that have to be merged into the repository before
merging this pull request.
-->
