### PR TITLE
Add print to .tex file example to examples.ipynb

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -180,7 +180,7 @@
        "<latexify.frontend.LatexifiedFunction at 0x7f58824de860>"
       ],
       "text/plain": [
-       "The above equation is sent to a new file, latexifyExample.txt"
+       "The above equation is sent to a new file, latexifyExample.tex"
       ]
      },
      "execution_count": 6,
@@ -194,9 +194,8 @@
     "def solve1(a, b, c):\n",
     "    return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)\n",
     "\n",
-    "file1 = open('latexifyExample.tex', 'w')\n",
-    "file1.write(str(solve1))\n",
-    "file1.close()\n"
+    "with open('latexifyExample.tex', 'w') as fp: \n",
+    "\t print(solve1, file = fp) \n",
    ]
   }
  ],

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -178,9 +178,6 @@
       ],
       "text/plain": [
        "<latexify.frontend.LatexifiedFunction at 0x7f58824de860>"
-      ],
-      "text/plain": [
-       "The above equation is sent to a new file, latexifyExample.tex"
       ]
      },
      "execution_count": 6,

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -165,6 +165,34 @@
     "\n",
     "solve"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$ \\displaystyle \\frac{-b + \\sqrt{b^{{2}} - {4}ac}}{{2}a} $$"
+      ],
+      "text/plain": [
+       "<latexify.frontend.LatexifiedFunction at 0x7f58824de860>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# latexify.expression works similarly, but the result does not contain the signature.\n",
+    "@latexify.expression\n",
+    "def solve(a, b, c):\n",
+    "    return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)\n",
+    "\n",
+    "solve"
+   ]
   }
  ],
  "metadata": {

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -195,7 +195,7 @@
     "    return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)\n",
     "\n",
     "with open('latexifyExample.tex', 'w') as fp: \n",
-    "\t print(solve1, file = fp) \n",
+    "\t print(solve1, file = fp) \n"
    ]
   }
  ],

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -195,7 +195,7 @@
     "    return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)\n",
     "\n",
     "with open('latexifyExample.tex', 'w') as fp: \n",
-    "\t print(solve1, file = fp) \n"
+    "    print(solve1, file = fp) \n"
    ]
   }
  ],

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -173,11 +173,14 @@
    "outputs": [
     {
      "data": {
-      "text/latex": [
+      "text/plain": [
        "$$ \\displaystyle \\frac{-b + \\sqrt{b^{{2}} - {4}ac}}{{2}a} $$"
       ],
       "text/plain": [
        "<latexify.frontend.LatexifiedFunction at 0x7f58824de860>"
+      ],
+      "text/plain": [
+       "The above equation is sent to a new file, latexifyExample.txt"
       ]
      },
      "execution_count": 6,

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -186,12 +186,14 @@
     }
    ],
    "source": [
-    "# latexify.expression works similarly, but the result does not contain the signature.\n",
+    "# We can also print the output to a .tex file\n",
     "@latexify.expression\n",
-    "def solve(a, b, c):\n",
+    "def solve1(a, b, c):\n",
     "    return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)\n",
     "\n",
-    "solve"
+    "file1 = open('latexifyExample.tex', 'w')\n",
+    "file1.write(str(solve1))\n",
+    "file1.close()\n"
    ]
   }
  ],


### PR DESCRIPTION
# Overview


Adding the functionality of printing to a .tex file to the examples.ipynb file.


# Details

Adds a new block to the python notebook duplicating the solve function into solve1. The code opens a new file, latexifyExample.tex, and prints the solve function in latex syntax to this file. 

# References

Issue #198

# Blocked by

None
