### PR TITLE
Change identifier replacer to allow for all valid Python identifiers

### DIFF
--- a/src/latexify/transformers/identifier_replacer.py
+++ b/src/latexify/transformers/identifier_replacer.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import ast
-import re
+import keyword
 import sys
-from typing import ClassVar, cast
+from typing import cast
 
 
 class IdentifierReplacer(ast.NodeTransformer):
@@ -24,8 +24,6 @@ class IdentifierReplacer(ast.NodeTransformer):
             return z
     """
 
-    _IDENTIFIER_PATTERN: ClassVar[re.Pattern] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
     def __init__(self, mapping: dict[str, str]):
         """Initializer.
 
@@ -38,9 +36,9 @@ class IdentifierReplacer(ast.NodeTransformer):
         self._mapping = mapping
 
         for k, v in self._mapping.items():
-            if not self._IDENTIFIER_PATTERN.match(k):
+            if not str.isidentifier(k) or keyword.iskeyword(k):
                 raise ValueError(f"'{k}' is not an identifier name.")
-            if not self._IDENTIFIER_PATTERN.match(v):
+            if not str.isidentifier(v) or keyword.iskeyword(v):
                 raise ValueError(f"'{v}' is not an identifier name.")
 
     def _replace_args(self, args: list[ast.arg]) -> list[ast.arg]:

--- a/src/latexify/transformers/identifier_replacer_test.py
+++ b/src/latexify/transformers/identifier_replacer_test.py
@@ -15,6 +15,8 @@ def test_invalid_mapping() -> None:
         IdentifierReplacer({"123": "foo"})
     with pytest.raises(ValueError, match=r"'456' is not an identifier name."):
         IdentifierReplacer({"foo": "456"})
+    with pytest.raises(ValueError, match=r"'def' is not an identifier name."):
+        IdentifierReplacer({"foo": "def"})
 
 
 def test_name_replaced() -> None:


### PR DESCRIPTION
# Overview

Change check for valid identifiers from 

```python
_IDENTIFIER_PATTERN: ClassVar[re.Pattern] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
```

to using the stdlib Python functions `str.isidentifier` and `keyword.iskeyword`


# Details

The previous identifier pattern has two problems.  
a) It blocks a lot of names as a lot of UTF-8 characters, e.g. `α` , are valid identifiers
b) It doesn't block invalid keywords as Python names, e.g. `def`

The stdlib `str.isidentifier` and `keyword.iskeyword` functions allow to correctly check for both cases and as a bonus are maintained by the Python folks, so new keyword additions etc. aren't a problem

I replaced the check in the `IdentifierReplacer` class and added an additional check for the `def` keyword in the test cases.

As a side note: is it necessary to check for the key to be a valid Python identifier? Since the key comes from parsing an existing Python function it cannot be invalid in the first place
